### PR TITLE
Decoded Raster Layer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     "deck.gl": "^8.9.31",
     "export-to-csv": "1.2.1",
     "express": "4.18.2",
+    "glslify": "^7.1.1",
     "jotai": "^2.5.0",
     "lodash-es": "^4.17.21",
     "mapbox-gl": "2.15.0",

--- a/client/src/app/(app)/layout.tsx
+++ b/client/src/app/(app)/layout.tsx
@@ -38,10 +38,12 @@ export default async function AppLayout({ children }: PropsWithChildren) {
   await queryClient.prefetchQuery(getGetCountriesQueryOptions(GET_COUNTRIES_OPTIONS));
 
   // Prefetch categories
-  await queryClient.prefetchQuery(getGetCategoriesQueryOptions(GET_CATEGORIES_OPTIONS()));
+  await queryClient.prefetchQuery(
+    getGetCategoriesQueryOptions(GET_CATEGORIES_OPTIONS("", searchParams.get("preview") || "")),
+  );
 
   const CATEGORIES = queryClient.getQueryData<CategoryListResponse>(
-    getGetCategoriesQueryKey(GET_CATEGORIES_OPTIONS()),
+    getGetCategoriesQueryKey(GET_CATEGORIES_OPTIONS("", searchParams.get("preview") || "")),
   );
 
   for (const category of CATEGORIES?.data || []) {
@@ -49,7 +51,9 @@ export default async function AppLayout({ children }: PropsWithChildren) {
 
     // Prefetch datasets
     await queryClient.prefetchQuery(
-      getGetDatasetsQueryOptions(GET_DATASETS_OPTIONS("", category.id)),
+      getGetDatasetsQueryOptions(
+        GET_DATASETS_OPTIONS("", category.id, searchParams.get("preview") || ""),
+      ),
     );
   }
 

--- a/client/src/app/parsers.ts
+++ b/client/src/app/parsers.ts
@@ -26,3 +26,4 @@ export const countriesComparisonParser = parseAsArrayOf(parseAsString).withDefau
 export const projectParser = parseAsInteger;
 export const pillarsParser = parseAsArrayOf(parseAsInteger).withDefault([]);
 export const availableForFundingParser = parseAsBoolean.withDefault(false);
+export const publicationStateParser = parseAsString.withDefault("live");

--- a/client/src/app/store.ts
+++ b/client/src/app/store.ts
@@ -11,6 +11,7 @@ import {
   layersSettingsParser,
   mapSettingsParser,
   pillarsParser,
+  publicationStateParser,
   projectParser,
 } from "@/app/parsers";
 
@@ -54,6 +55,10 @@ export const useSyncAvailableForFunding = () => {
   return useQueryState("available_for_funding", availableForFundingParser);
 };
 
+export const useSyncPublicationState = () => {
+  return useQueryState("publicationState", publicationStateParser);
+};
+
 export const useSyncSearchParams = () => {
   const [datasets] = useSyncDatasets();
   const [layers] = useSyncLayers();
@@ -65,6 +70,7 @@ export const useSyncSearchParams = () => {
   const [project] = useSyncProject();
   const [pillars] = useSyncPillars();
   const [availableForFunding] = useSyncAvailableForFunding();
+  const [publicationState] = useSyncPublicationState();
 
   const sp = new URLSearchParams();
 
@@ -95,6 +101,10 @@ export const useSyncSearchParams = () => {
   if (availableForFundingParser.defaultValue !== availableForFunding) {
     sp.set("available_for_funding", availableForFundingParser.serialize(!!availableForFunding));
   }
+
+  // Preview
+  if (publicationStateParser.defaultValue !== publicationState)
+    sp.set("preview", publicationStateParser.serialize(publicationState));
 
   return sp;
 };

--- a/client/src/components/map/layers/deck-layer/index.tsx
+++ b/client/src/components/map/layers/deck-layer/index.tsx
@@ -8,7 +8,6 @@ import { useDeckMapboxOverlay } from "@/components/map/provider";
 
 export type DeckLayerProps<T> = LayerProps &
   Partial<T> & {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     config: Layer | null;
   };
 

--- a/client/src/components/map/layers/deck-layer/index.tsx
+++ b/client/src/components/map/layers/deck-layer/index.tsx
@@ -1,31 +1,22 @@
 "use client";
 
-import { useEffect } from "react";
+import { Layer } from "deck.gl/typed";
 
 import { LayerProps } from "@/types/layers";
 
-import { useDeckMapboxOverlayContext } from "@/components/map/provider";
+import { useDeckMapboxOverlay } from "@/components/map/provider";
 
 export type DeckLayerProps<T> = LayerProps &
   Partial<T> & {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    config: any;
+    config: Layer | null;
   };
 
 const DeckJsonLayer = <T,>({ id, config }: DeckLayerProps<T>) => {
-  // Render deck config
-  const i = `${id}-deck`;
-  const { addLayer, removeLayer } = useDeckMapboxOverlayContext();
-
-  useEffect(() => {
-    addLayer(config.clone({ id: i, beforeId: id }));
-  }, [i, id, config, addLayer]);
-
-  useEffect(() => {
-    return () => {
-      removeLayer(i);
-    };
-  }, [i, removeLayer]);
+  useDeckMapboxOverlay({
+    id: `${id}`,
+    layer: config,
+  });
 
   return null;
 };

--- a/client/src/components/map/layers/decode-layer/component.tsx
+++ b/client/src/components/map/layers/decode-layer/component.tsx
@@ -1,13 +1,19 @@
+import { useMemo } from "react";
+
 import { GeoBoundingBox, TileLayer } from "@deck.gl/geo-layers/typed";
 import { BitmapLayer } from "@deck.gl/layers/typed";
 import GL from "@luma.gl/constants";
+import { Layer } from "deck.gl/typed";
 import { RasterSource } from "mapbox-gl";
 
-import { LayerProps } from "@/types/layers";
+import { useGetCategories } from "@/types/generated/category";
 
 import DecodeExtension from "@/components/map/layers/decode-layer/extension";
+import { useDeckMapboxOverlay } from "@/components/map/provider";
 
-export interface DecodeLayerProps extends LayerProps {
+export interface DecodeLayerComponentProps {
+  id: string;
+  beforeId: string;
   source: RasterSource;
   opacity: number;
   visibility: boolean;
@@ -15,15 +21,19 @@ export interface DecodeLayerProps extends LayerProps {
   decodeParams: Record<string, unknown>;
 }
 
-class DecodeLayer {
-  constructor({ id, source, visibility, opacity, decodeFunction, decodeParams }: DecodeLayerProps) {
-    return new TileLayer<
-      unknown,
-      {
-        decodeFunction: DecodeLayerProps["decodeFunction"];
-        decodeParams: DecodeLayerProps["decodeParams"];
-      }
-    >({
+export default function DecodeLayerComponent({
+  id,
+  source,
+  visibility,
+  opacity,
+  decodeFunction,
+  decodeParams,
+}: DecodeLayerComponentProps) {
+  const { data } = useGetCategories();
+  console.info(data);
+
+  const layer: Layer = useMemo(() => {
+    return new TileLayer<unknown, DecodeLayerComponentProps>({
       id,
       data: source.tiles,
       tileSize: source.tileSize ?? 256,
@@ -72,7 +82,12 @@ class DecodeLayer {
         return null;
       },
     });
-  }
-}
+  }, [id, decodeFunction, decodeParams, source, opacity, visibility]);
 
-export default DecodeLayer;
+  useDeckMapboxOverlay({
+    id,
+    layer,
+  });
+
+  return null;
+}

--- a/client/src/components/map/layers/decode-layer/extension.tsx
+++ b/client/src/components/map/layers/decode-layer/extension.tsx
@@ -1,0 +1,38 @@
+import { Layer, LayerExtension } from "@deck.gl/core/typed";
+
+type DecodeExtensionType = Layer<{
+  decodeFunction: string;
+  decodeParams: Record<string, unknown>;
+  zoom: number;
+}>;
+
+export default class DecodeExtension extends LayerExtension {
+  getShaders(this: DecodeExtensionType) {
+    return {
+      inject: {
+        "fs:#decl": `
+          uniform float zoom;
+          uniform float startYear;
+          uniform float endYear;
+        `,
+
+        "fs:DECKGL_FILTER_COLOR": `
+          ${this.props.decodeFunction}
+        `,
+      },
+    };
+  }
+
+  updateState(this: DecodeExtensionType) {
+    const { decodeParams = {}, zoom } = this.props;
+
+    for (const model of this.getModels()) {
+      model.setUniforms({
+        zoom,
+        ...decodeParams,
+      });
+    }
+  }
+}
+
+DecodeExtension.extensionName = "DecodeExtension";

--- a/client/src/components/map/layers/decode-layer/extension.tsx
+++ b/client/src/components/map/layers/decode-layer/extension.tsx
@@ -10,7 +10,7 @@ export default class DecodeExtension extends LayerExtension {
   getShaders(this: DecodeExtensionType) {
     return {
       inject: {
-        "fs:#decl": `
+        "fs:#decl": /*glsl*/ `
           uniform float zoom;
           uniform float startYear;
           uniform float endYear;

--- a/client/src/components/map/layers/decode-layer/index.tsx
+++ b/client/src/components/map/layers/decode-layer/index.tsx
@@ -1,0 +1,109 @@
+import { Layer, LayerExtension } from "@deck.gl/core/typed";
+import { GeoBoundingBox, TileLayer } from "@deck.gl/geo-layers/typed";
+import { BitmapLayer } from "@deck.gl/layers/typed";
+import GL from "@luma.gl/constants";
+import { RasterLayer, RasterSource } from "mapbox-gl";
+
+export interface DecodeLayerProps {
+  source: RasterSource;
+  styles: RasterLayer[];
+  decodeFunction: string;
+  decodeParams: Record<string, unknown>;
+}
+
+type DecodeExtensionType = Layer<{
+  decodeFunction: string;
+  decodeParams: Record<string, unknown>;
+  zoom: number;
+}>;
+
+class DecodeExtension extends LayerExtension {
+  getShaders(this: DecodeExtensionType) {
+    return {
+      inject: {
+        "fs:#decl": `
+          uniform float zoom;
+          uniform float startYear;
+          uniform float endYear;
+        `,
+
+        "fs:DECKGL_FILTER_COLOR": `
+          ${this.props.decodeFunction}
+        `,
+      },
+    };
+  }
+
+  updateState(this: DecodeExtensionType) {
+    const { decodeParams = {}, zoom } = this.props;
+
+    for (const model of this.getModels()) {
+      model.setUniforms({
+        zoom,
+        ...decodeParams,
+      });
+    }
+  }
+}
+
+class DecodeLayer {
+  constructor({ source, styles, decodeFunction, decodeParams }: DecodeLayerProps) {
+    return new TileLayer<
+      unknown,
+      {
+        decodeFunction: DecodeLayerProps["decodeFunction"];
+        decodeParams: DecodeLayerProps["decodeParams"];
+      }
+    >({
+      id: styles[0].id,
+      data: source.tiles,
+      tileSize: source.tileSize ?? 256,
+      minZoom: source.minzoom,
+      maxZoom: source.maxzoom,
+      visible: (styles[0].layout?.visibility as unknown as boolean) ?? true,
+      opacity: (styles[0].paint?.["raster-opacity"] as number) ?? 1,
+      refinementStrategy: "no-overlap",
+      decodeFunction,
+      decodeParams,
+      renderSubLayers: (subLayer) => {
+        const {
+          id: subLayerId,
+          data: subLayerData,
+          tile: subLayerTile,
+          visible: subLayerVisible,
+          opacity: subLayerOpacity,
+        } = subLayer;
+
+        const { zoom } = subLayerTile;
+        const { west, south, east, north } = subLayerTile.bbox as GeoBoundingBox;
+
+        if (subLayerData) {
+          return new BitmapLayer({
+            id: subLayerId,
+            image: subLayerData,
+            bounds: [west, south, east, north],
+            textureParameters: {
+              [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
+              [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
+              [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
+              [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE,
+            },
+            zoom,
+            visible: subLayerVisible,
+            opacity: subLayerOpacity,
+            decodeParams,
+            decodeFunction,
+            extensions: [new DecodeExtension()],
+            updateTriggers: {
+              decodeParams,
+              decodeFunction,
+            },
+          });
+        }
+        return null;
+      },
+    });
+  }
+}
+
+export default DecodeLayer;

--- a/client/src/components/map/layers/ring-layer/capitals.json
+++ b/client/src/components/map/layers/ring-layer/capitals.json
@@ -1,0 +1,3125 @@
+{
+  "type": "FeatureCollection",
+  "features": [{
+      "properties": {
+          "country": "Bangladesh",
+          "city": "Dhaka",
+          "tld": "bd",
+          "iso3": "BGD",
+          "iso2": "BD"
+      },
+      "geometry": {
+          "coordinates": [90.24, 23.43],
+          "type": "Point"
+      },
+      "id": "BD"
+  }, {
+      "properties": {
+          "country": "Belgium",
+          "city": "Brussels",
+          "tld": "be",
+          "iso3": "BEL",
+          "iso2": "BE"
+      },
+      "geometry": {
+          "coordinates": [4.2, 50.5],
+          "type": "Point"
+      },
+      "id": "BE"
+  }, {
+      "properties": {
+          "country": "Burkina Faso",
+          "city": "Ouagadougou",
+          "tld": "bf",
+          "iso3": "BFA",
+          "iso2": "BF"
+      },
+      "geometry": {
+          "coordinates": [-1.31, 12.22],
+          "type": "Point"
+      },
+      "id": "BF"
+  }, {
+      "properties": {
+          "country": "Bulgaria",
+          "city": "Sofia",
+          "tld": "bg",
+          "iso3": "BGR",
+          "iso2": "BG"
+      },
+      "geometry": {
+          "coordinates": [23.19, 42.41],
+          "type": "Point"
+      },
+      "id": "BG"
+  }, {
+      "properties": {
+          "country": "Bosnia and Herzegovina",
+          "city": "Sarajevo",
+          "tld": "ba",
+          "iso3": "BIH",
+          "iso2": "BA"
+      },
+      "geometry": {
+          "coordinates": [18.25, 43.52],
+          "type": "Point"
+      },
+      "id": "BA"
+  }, {
+      "properties": {
+          "country": "Barbados",
+          "city": "Bridgetown",
+          "tld": "bb",
+          "iso3": "BRB",
+          "iso2": "BB"
+      },
+      "geometry": {
+          "coordinates": [-59.37, 13.06],
+          "type": "Point"
+      },
+      "id": "BB"
+  }, {
+      "properties": {
+          "country": "Wallis and Futuna",
+          "city": "Mata-Utu",
+          "tld": "wf",
+          "iso3": "WLF",
+          "iso2": "WF"
+      },
+      "geometry": {
+          "coordinates": [-171.56, -13.57],
+          "type": "Point"
+      },
+      "id": "WF"
+  }, {
+      "properties": {
+          "country": "Saint Barthelemy",
+          "city": "Gustavia",
+          "tld": "bl",
+          "iso3": "BLM",
+          "iso2": "BL"
+      },
+      "geometry": {
+          "coordinates": [-62.51, 17.53],
+          "type": "Point"
+      },
+      "id": "BL"
+  }, {
+      "properties": {
+          "country": "Bermuda",
+          "city": "Hamilton",
+          "tld": "bm",
+          "iso3": "BMU",
+          "iso2": "BM"
+      },
+      "geometry": {
+          "coordinates": [-64.47, 32.17],
+          "type": "Point"
+      },
+      "id": "BM"
+  }, {
+      "properties": {
+          "country": "Brunei",
+          "city": "Bandar Seri Begawan",
+          "tld": "bn",
+          "iso3": "BRN",
+          "iso2": "BN"
+      },
+      "geometry": {
+          "coordinates": [114.56, 4.53],
+          "type": "Point"
+      },
+      "id": "BN"
+  }, {
+      "properties": {
+          "country": "Bolivia",
+          "city": "La Paz",
+          "tld": "bo",
+          "iso3": "BOL",
+          "iso2": "BO"
+      },
+      "geometry": {
+          "coordinates": [-68.09, -16.3],
+          "type": "Point"
+      },
+      "id": "BO"
+  }, {
+      "properties": {
+          "country": "Bahrain",
+          "city": "Manama",
+          "tld": "bh",
+          "iso3": "BHR",
+          "iso2": "BH"
+      },
+      "geometry": {
+          "coordinates": [50.34, 26.14],
+          "type": "Point"
+      },
+      "id": "BH"
+  }, {
+      "properties": {
+          "country": "Burundi",
+          "city": "Bujumbura",
+          "tld": "bi",
+          "iso3": "BDI",
+          "iso2": "BI"
+      },
+      "geometry": {
+          "coordinates": [29.21, -3.22],
+          "type": "Point"
+      },
+      "id": "BI"
+  }, {
+      "properties": {
+          "country": "Benin",
+          "city": "Porto-Novo",
+          "tld": "bj",
+          "iso3": "BEN",
+          "iso2": "BJ"
+      },
+      "geometry": {
+          "coordinates": [2.37, 6.29],
+          "type": "Point"
+      },
+      "id": "BJ"
+  }, {
+      "properties": {
+          "country": "Bhutan",
+          "city": "Thimphu",
+          "tld": "bt",
+          "iso3": "BTN",
+          "iso2": "BT"
+      },
+      "geometry": {
+          "coordinates": [89.36, 27.29],
+          "type": "Point"
+      },
+      "id": "BT"
+  }, {
+      "properties": {
+          "country": "Jamaica",
+          "city": "Kingston",
+          "tld": "jm",
+          "iso3": "JAM",
+          "iso2": "JM"
+      },
+      "geometry": {
+          "coordinates": [-76.48, 18],
+          "type": "Point"
+      },
+      "id": "JM"
+  }, {
+      "properties": {
+          "country": "Bouvet Island",
+          "tld": "bv",
+          "iso3": "BVT",
+          "iso2": "BV"
+      },
+      "geometry": {
+          "coordinates": [3.24, -54.26],
+          "type": "Point"
+      },
+      "id": "BV"
+  }, {
+      "properties": {
+          "country": "Botswana",
+          "city": "Gaborone",
+          "tld": "bw",
+          "iso3": "BWA",
+          "iso2": "BW"
+      },
+      "geometry": {
+          "coordinates": [25.55, -24.45],
+          "type": "Point"
+      },
+      "id": "BW"
+  }, {
+      "properties": {
+          "country": "Samoa",
+          "city": "Apia",
+          "tld": "ws",
+          "iso3": "WSM",
+          "iso2": "WS"
+      },
+      "geometry": {
+          "coordinates": [-171.44, -13.5],
+          "type": "Point"
+      },
+      "id": "WS"
+  }, {
+      "properties": {
+          "country": "Brazil",
+          "city": "Brasilia",
+          "tld": "br",
+          "iso3": "BRA",
+          "iso2": "BR"
+      },
+      "geometry": {
+          "coordinates": [-47.55, -15.47],
+          "type": "Point"
+      },
+      "id": "BR"
+  }, {
+      "properties": {
+          "country": "Bahamas",
+          "city": "Nassau",
+          "tld": "bs",
+          "iso3": "BHS",
+          "iso2": "BS"
+      },
+      "geometry": {
+          "coordinates": [-77.21, 25.05],
+          "type": "Point"
+      },
+      "id": "BS"
+  }, {
+      "properties": {
+          "country": "Jersey",
+          "city": "Saint Helier",
+          "tld": "je",
+          "iso3": "JEY",
+          "iso2": "JE"
+      },
+      "geometry": {
+          "coordinates": [-2.06, 49.11],
+          "type": "Point"
+      },
+      "id": "JE"
+  }, {
+      "properties": {
+          "country": "Belarus",
+          "city": "Minsk",
+          "tld": "by",
+          "iso3": "BLR",
+          "iso2": "BY"
+      },
+      "geometry": {
+          "coordinates": [27.34, 53.54],
+          "type": "Point"
+      },
+      "id": "BY"
+  }, {
+      "properties": {
+          "country": "Belize",
+          "city": "Belmopan",
+          "tld": "bz",
+          "iso3": "BLZ",
+          "iso2": "BZ"
+      },
+      "geometry": {
+          "coordinates": [-88.46, 17.15],
+          "type": "Point"
+      },
+      "id": "BZ"
+  }, {
+      "properties": {
+          "country": "Russia",
+          "city": "Moscow",
+          "tld": "ru",
+          "iso3": "RUS",
+          "iso2": "RU"
+      },
+      "geometry": {
+          "coordinates": [37.35, 55.45],
+          "type": "Point"
+      },
+      "id": "RU"
+  }, {
+      "properties": {
+          "country": "Rwanda",
+          "city": "Kigali",
+          "tld": "rw",
+          "iso3": "RWA",
+          "iso2": "RW"
+      },
+      "geometry": {
+          "coordinates": [30.04, -1.57],
+          "type": "Point"
+      },
+      "id": "RW"
+  }, {
+      "properties": {
+          "country": "Serbia",
+          "city": "Belgrade",
+          "tld": "rs",
+          "iso3": "SRB",
+          "iso2": "RS"
+      },
+      "geometry": {
+          "coordinates": [20.3, 44.5],
+          "type": "Point"
+      },
+      "id": "RS"
+  }, {
+      "properties": {
+          "country": "Timor-Leste",
+          "city": "Dili",
+          "tld": "tl",
+          "iso3": "TLS",
+          "iso2": "TL"
+      },
+      "geometry": {
+          "coordinates": [125.36, -8.35],
+          "type": "Point"
+      },
+      "id": "TL"
+  }, {
+      "properties": {
+          "country": "Turkmenistan",
+          "city": "Ashgabat",
+          "tld": "tm",
+          "iso3": "TKM",
+          "iso2": "TM"
+      },
+      "geometry": {
+          "coordinates": [58.23, 37.57],
+          "type": "Point"
+      },
+      "id": "TM"
+  }, {
+      "properties": {
+          "country": "Tajikistan",
+          "city": "Dushanbe",
+          "tld": "tj",
+          "iso3": "TJK",
+          "iso2": "TJ"
+      },
+      "geometry": {
+          "coordinates": [68.48, 38.35],
+          "type": "Point"
+      },
+      "id": "TJ"
+  }, {
+      "properties": {
+          "country": "Romania",
+          "city": "Bucharest",
+          "tld": "ro",
+          "iso3": "ROU",
+          "iso2": "RO"
+      },
+      "geometry": {
+          "coordinates": [26.06, 44.26],
+          "type": "Point"
+      },
+      "id": "RO"
+  }, {
+      "properties": {
+          "country": "Tokelau",
+          "tld": "tk",
+          "iso3": "TKL",
+          "iso2": "TK"
+      },
+      "geometry": {
+          "coordinates": [-172, -9],
+          "type": "Point"
+      },
+      "id": "TK"
+  }, {
+      "properties": {
+          "country": "Guinea-Bissau",
+          "city": "Bissau",
+          "tld": "gw",
+          "iso3": "GNB",
+          "iso2": "GW"
+      },
+      "geometry": {
+          "coordinates": [-15.35, 11.51],
+          "type": "Point"
+      },
+      "id": "GW"
+  }, {
+      "properties": {
+          "country": "Guam",
+          "city": "Hagatna",
+          "tld": "gu",
+          "iso3": "GUM",
+          "iso2": "GU"
+      },
+      "geometry": {
+          "coordinates": [144.44, 13.28],
+          "type": "Point"
+      },
+      "id": "GU"
+  }, {
+      "properties": {
+          "country": "Guatemala",
+          "city": "Guatemala City",
+          "tld": "gt",
+          "iso3": "GTM",
+          "iso2": "GT"
+      },
+      "geometry": {
+          "coordinates": [-90.31, 14.37],
+          "type": "Point"
+      },
+      "id": "GT"
+  }, {
+      "properties": {
+          "country": "Greece",
+          "city": "Athens",
+          "tld": "gr",
+          "iso3": "GRC",
+          "iso2": "GR"
+      },
+      "geometry": {
+          "coordinates": [23.44, 37.59],
+          "type": "Point"
+      },
+      "id": "GR"
+  }, {
+      "properties": {
+          "country": "Equatorial Guinea",
+          "city": "Malabo",
+          "tld": "gq",
+          "iso3": "GNQ",
+          "iso2": "GQ"
+      },
+      "geometry": {
+          "coordinates": [8.47, 3.45],
+          "type": "Point"
+      },
+      "id": "GQ"
+  }, {
+      "properties": {
+          "country": "Japan",
+          "city": "Tokyo",
+          "tld": "jp",
+          "iso3": "JPN",
+          "iso2": "JP"
+      },
+      "geometry": {
+          "coordinates": [139.45, 35.41],
+          "type": "Point"
+      },
+      "id": "JP"
+  }, {
+      "properties": {
+          "country": "Guyana",
+          "city": "Georgetown",
+          "tld": "gy",
+          "iso3": "GUY",
+          "iso2": "GY"
+      },
+      "geometry": {
+          "coordinates": [-58.1, 6.48],
+          "type": "Point"
+      },
+      "id": "GY"
+  }, {
+      "properties": {
+          "country": "Guernsey",
+          "city": "Saint Peter Port",
+          "tld": "gg",
+          "iso3": "GGY",
+          "iso2": "GG"
+      },
+      "geometry": {
+          "coordinates": [-2.32, 49.27],
+          "type": "Point"
+      },
+      "id": "GG"
+  }, {
+      "properties": {
+          "country": "Georgia",
+          "city": "T'bilisi",
+          "tld": "ge",
+          "iso3": "GEO",
+          "iso2": "GE"
+      },
+      "geometry": {
+          "coordinates": [44.47, 41.43],
+          "type": "Point"
+      },
+      "id": "GE"
+  }, {
+      "properties": {
+          "country": "Grenada",
+          "city": "Saint George's",
+          "tld": "gd",
+          "iso3": "GRD",
+          "iso2": "GD"
+      },
+      "geometry": {
+          "coordinates": [-61.45, 12.03],
+          "type": "Point"
+      },
+      "id": "GD"
+  }, {
+      "properties": {
+          "country": "United Kingdom",
+          "city": "London",
+          "tld": "uk",
+          "iso3": "GBR",
+          "iso2": "GB"
+      },
+      "geometry": {
+          "coordinates": [-0.1, 51.3],
+          "type": "Point"
+      },
+      "id": "GB"
+  }, {
+      "properties": {
+          "country": "Gabon",
+          "city": "Libreville",
+          "tld": "ga",
+          "iso3": "GAB",
+          "iso2": "GA"
+      },
+      "geometry": {
+          "coordinates": [9.27, 0.23],
+          "type": "Point"
+      },
+      "id": "GA"
+  }, {
+      "properties": {
+          "country": "El Salvador",
+          "city": "San Salvador",
+          "tld": "sv",
+          "iso3": "SLV",
+          "iso2": "SV"
+      },
+      "geometry": {
+          "coordinates": [-89.12, 13.42],
+          "type": "Point"
+      },
+      "id": "SV"
+  }, {
+      "properties": {
+          "country": "Guinea",
+          "city": "Conakry",
+          "tld": "gn",
+          "iso3": "GIN",
+          "iso2": "GN"
+      },
+      "geometry": {
+          "coordinates": [-13.42, 9.33],
+          "type": "Point"
+      },
+      "id": "GN"
+  }, {
+      "properties": {
+          "country": "Gambia",
+          "city": "Banjul",
+          "tld": "gm",
+          "iso3": "GMB",
+          "iso2": "GM"
+      },
+      "geometry": {
+          "coordinates": [-16.34, 13.27],
+          "type": "Point"
+      },
+      "id": "GM"
+  }, {
+      "properties": {
+          "country": "Greenland",
+          "city": "Nuuk",
+          "tld": "gl",
+          "iso3": "GRL",
+          "iso2": "GL"
+      },
+      "geometry": {
+          "coordinates": [-51.45, 64.11],
+          "type": "Point"
+      },
+      "id": "GL"
+  }, {
+      "properties": {
+          "country": "Gibraltar",
+          "city": "Gibraltar",
+          "tld": "gi",
+          "iso3": "GIB",
+          "iso2": "GI"
+      },
+      "geometry": {
+          "coordinates": [-5.21, 36.08],
+          "type": "Point"
+      },
+      "id": "GI"
+  }, {
+      "properties": {
+          "country": "Ghana",
+          "city": "Accra",
+          "tld": "gh",
+          "iso3": "GHA",
+          "iso2": "GH"
+      },
+      "geometry": {
+          "coordinates": [-0.13, 5.33],
+          "type": "Point"
+      },
+      "id": "GH"
+  }, {
+      "properties": {
+          "country": "Oman",
+          "city": "Muscat",
+          "tld": "om",
+          "iso3": "OMN",
+          "iso2": "OM"
+      },
+      "geometry": {
+          "coordinates": [58.35, 23.37],
+          "type": "Point"
+      },
+      "id": "OM"
+  }, {
+      "properties": {
+          "country": "Tunisia",
+          "city": "Tunis",
+          "tld": "tn",
+          "iso3": "TUN",
+          "iso2": "TN"
+      },
+      "geometry": {
+          "coordinates": [10.11, 36.48],
+          "type": "Point"
+      },
+      "id": "TN"
+  }, {
+      "properties": {
+          "country": "Jordan",
+          "city": "Amman",
+          "tld": "jo",
+          "iso3": "JOR",
+          "iso2": "JO"
+      },
+      "geometry": {
+          "coordinates": [35.56, 31.57],
+          "type": "Point"
+      },
+      "id": "JO"
+  }, {
+      "properties": {
+          "country": "Croatia",
+          "city": "Zagreb",
+          "tld": "hr",
+          "iso3": "HRV",
+          "iso2": "HR"
+      },
+      "geometry": {
+          "coordinates": [16, 45.48],
+          "type": "Point"
+      },
+      "id": "HR"
+  }, {
+      "properties": {
+          "country": "Haiti",
+          "city": "Port-au-Prince",
+          "tld": "ht",
+          "iso3": "HTI",
+          "iso2": "HT"
+      },
+      "geometry": {
+          "coordinates": [-72.2, 18.32],
+          "type": "Point"
+      },
+      "id": "HT"
+  }, {
+      "properties": {
+          "country": "Hungary",
+          "city": "Budapest",
+          "tld": "hu",
+          "iso3": "HUN",
+          "iso2": "HU"
+      },
+      "geometry": {
+          "coordinates": [19.05, 47.3],
+          "type": "Point"
+      },
+      "id": "HU"
+  }, {
+      "properties": {
+          "country": "Hong Kong",
+          "city": "Hong Kong",
+          "tld": "hk",
+          "iso3": "HKG",
+          "iso2": "HK"
+      },
+      "geometry": {
+          "coordinates": [114.1, 22.15],
+          "type": "Point"
+      },
+      "id": "HK"
+  }, {
+      "properties": {
+          "country": "Honduras",
+          "city": "Tegucigalpa",
+          "tld": "hn",
+          "iso3": "HND",
+          "iso2": "HN"
+      },
+      "geometry": {
+          "coordinates": [-87.13, 14.06],
+          "type": "Point"
+      },
+      "id": "HN"
+  }, {
+      "properties": {
+          "country": "Heard Island and McDonald Islands",
+          "tld": "hm",
+          "iso3": "HMD",
+          "iso2": "HM"
+      },
+      "geometry": {
+          "coordinates": [72.31, -53.06],
+          "type": "Point"
+      },
+      "id": "HM"
+  }, {
+      "properties": {
+          "country": "Venezuela",
+          "city": "Caracas",
+          "tld": "ve",
+          "iso3": "VEN",
+          "iso2": "VE"
+      },
+      "geometry": {
+          "coordinates": [-66.56, 10.3],
+          "type": "Point"
+      },
+      "id": "VE"
+  }, {
+      "properties": {
+          "country": "Puerto Rico",
+          "city": "San Juan",
+          "tld": "pr",
+          "iso3": "PRI",
+          "iso2": "PR"
+      },
+      "geometry": {
+          "coordinates": [-66.07, 18.28],
+          "type": "Point"
+      },
+      "id": "PR"
+  }, {
+      "properties": {
+          "country": "Palestinian Territory",
+          "tld": "ps",
+          "iso3": "PSE",
+          "iso2": "PS"
+      },
+      "geometry": {
+          "coordinates": [34.2, 31.25],
+          "type": "Point"
+      },
+      "id": "PS"
+  }, {
+      "properties": {
+          "country": "Palau",
+          "city": "Melekeok",
+          "tld": "pw",
+          "iso3": "PLW",
+          "iso2": "PW"
+      },
+      "geometry": {
+          "coordinates": [134.38, 7.29],
+          "type": "Point"
+      },
+      "id": "PW"
+  }, {
+      "properties": {
+          "country": "Portugal",
+          "city": "Lisbon",
+          "tld": "pt",
+          "iso3": "PRT",
+          "iso2": "PT"
+      },
+      "geometry": {
+          "coordinates": [-9.08, 38.43],
+          "type": "Point"
+      },
+      "id": "PT"
+  }, {
+      "properties": {
+          "country": "Svalbard",
+          "city": "Longyearbyen",
+          "tld": "sj",
+          "iso3": "SJM",
+          "iso2": "SJ"
+      },
+      "geometry": {
+          "coordinates": [15.33, 78.13],
+          "type": "Point"
+      },
+      "id": "SJ"
+  }, {
+      "properties": {
+          "country": "Paraguay",
+          "city": "Asuncion",
+          "tld": "py",
+          "iso3": "PRY",
+          "iso2": "PY"
+      },
+      "geometry": {
+          "coordinates": [-57.4, -25.16],
+          "type": "Point"
+      },
+      "id": "PY"
+  }, {
+      "properties": {
+          "country": "Iraq",
+          "city": "Baghdad",
+          "tld": "iq",
+          "iso3": "IRQ",
+          "iso2": "IQ"
+      },
+      "geometry": {
+          "coordinates": [44.23, 33.2],
+          "type": "Point"
+      },
+      "id": "IQ"
+  }, {
+      "properties": {
+          "country": "Panama",
+          "city": "Panama City",
+          "tld": "pa",
+          "iso3": "PAN",
+          "iso2": "PA"
+      },
+      "geometry": {
+          "coordinates": [-79.32, 8.58],
+          "type": "Point"
+      },
+      "id": "PA"
+  }, {
+      "properties": {
+          "country": "French Polynesia",
+          "city": "Papeete",
+          "tld": "pf",
+          "iso3": "PYF",
+          "iso2": "PF"
+      },
+      "geometry": {
+          "coordinates": [-149.34, -17.32],
+          "type": "Point"
+      },
+      "id": "PF"
+  }, {
+      "properties": {
+          "country": "Papua New Guinea",
+          "city": "Port Moresby",
+          "tld": "pg",
+          "iso3": "PNG",
+          "iso2": "PG"
+      },
+      "geometry": {
+          "coordinates": [147.1, -9.3],
+          "type": "Point"
+      },
+      "id": "PG"
+  }, {
+      "properties": {
+          "country": "Peru",
+          "city": "Lima",
+          "tld": "pe",
+          "iso3": "PER",
+          "iso2": "PE"
+      },
+      "geometry": {
+          "coordinates": [-77.03, -12.03],
+          "type": "Point"
+      },
+      "id": "PE"
+  }, {
+      "properties": {
+          "country": "Pakistan",
+          "city": "Islamabad",
+          "tld": "pk",
+          "iso3": "PAK",
+          "iso2": "PK"
+      },
+      "geometry": {
+          "coordinates": [73.1, 33.42],
+          "type": "Point"
+      },
+      "id": "PK"
+  }, {
+      "properties": {
+          "country": "Philippines",
+          "city": "Manila",
+          "tld": "ph",
+          "iso3": "PHL",
+          "iso2": "PH"
+      },
+      "geometry": {
+          "coordinates": [121, 14.35],
+          "type": "Point"
+      },
+      "id": "PH"
+  }, {
+      "properties": {
+          "country": "Pitcairn",
+          "city": "Adamstown",
+          "tld": "pn",
+          "iso3": "PCN",
+          "iso2": "PN"
+      },
+      "geometry": {
+          "coordinates": [-130.05, -25.04],
+          "type": "Point"
+      },
+      "id": "PN"
+  }, {
+      "properties": {
+          "country": "Poland",
+          "city": "Warsaw",
+          "tld": "pl",
+          "iso3": "POL",
+          "iso2": "PL"
+      },
+      "geometry": {
+          "coordinates": [21, 52.15],
+          "type": "Point"
+      },
+      "id": "PL"
+  }, {
+      "properties": {
+          "country": "Saint Pierre and Miquelon",
+          "city": "Saint-Pierre",
+          "tld": "pm",
+          "iso3": "SPM",
+          "iso2": "PM"
+      },
+      "geometry": {
+          "coordinates": [-56.11, 46.46],
+          "type": "Point"
+      },
+      "id": "PM"
+  }, {
+      "properties": {
+          "country": "Zambia",
+          "city": "Lusaka",
+          "tld": "zm",
+          "iso3": "ZMB",
+          "iso2": "ZM"
+      },
+      "geometry": {
+          "coordinates": [28.17, -15.25],
+          "type": "Point"
+      },
+      "id": "ZM"
+  }, {
+      "properties": {
+          "country": "Western Sahara",
+          "tld": "eh",
+          "iso3": "ESH",
+          "iso2": "EH"
+      },
+      "geometry": {
+          "coordinates": [-13, 24.3],
+          "type": "Point"
+      },
+      "id": "EH"
+  }, {
+      "properties": {
+          "country": "Estonia",
+          "city": "Tallinn",
+          "tld": "ee",
+          "iso3": "EST",
+          "iso2": "EE"
+      },
+      "geometry": {
+          "coordinates": [24.43, 59.26],
+          "type": "Point"
+      },
+      "id": "EE"
+  }, {
+      "properties": {
+          "country": "Egypt",
+          "city": "Cairo",
+          "tld": "eg",
+          "iso3": "EGY",
+          "iso2": "EG"
+      },
+      "geometry": {
+          "coordinates": [31.15, 30.03],
+          "type": "Point"
+      },
+      "id": "EG"
+  }, {
+      "properties": {
+          "country": "South Africa",
+          "city": "Pretoria",
+          "tld": "za",
+          "iso3": "ZAF",
+          "iso2": "ZA"
+      },
+      "geometry": {
+          "coordinates": [28.13, -25.42],
+          "type": "Point"
+      },
+      "id": "ZA"
+  }, {
+      "properties": {
+          "country": "Ecuador",
+          "city": "Quito",
+          "tld": "ec",
+          "iso3": "ECU",
+          "iso2": "EC"
+      },
+      "geometry": {
+          "coordinates": [-78.3, -0.13],
+          "type": "Point"
+      },
+      "id": "EC"
+  }, {
+      "properties": {
+          "country": "Italy",
+          "city": "Rome",
+          "tld": "it",
+          "iso3": "ITA",
+          "iso2": "IT"
+      },
+      "geometry": {
+          "coordinates": [12.29, 41.54],
+          "type": "Point"
+      },
+      "id": "IT"
+  }, {
+      "properties": {
+          "country": "Vietnam",
+          "city": "Hanoi",
+          "tld": "vn",
+          "iso3": "VNM",
+          "iso2": "VN"
+      },
+      "geometry": {
+          "coordinates": [105.51, 21.02],
+          "type": "Point"
+      },
+      "id": "VN"
+  }, {
+      "properties": {
+          "country": "Solomon Islands",
+          "city": "Honiara",
+          "tld": "sb",
+          "iso3": "SLB",
+          "iso2": "SB"
+      },
+      "geometry": {
+          "coordinates": [159.57, -9.26],
+          "type": "Point"
+      },
+      "id": "SB"
+  }, {
+      "properties": {
+          "country": "European Union",
+          "tld": "eu",
+          "iso3": "N/A",
+          "iso2": "EU"
+      },
+      "geometry": {
+          "coordinates": [9.9, 50.1021],
+          "type": "Point"
+      },
+      "id": "EU"
+  }, {
+      "properties": {
+          "country": "Ethiopia",
+          "city": "Addis Ababa",
+          "tld": "et",
+          "iso3": "ETH",
+          "iso2": "ET"
+      },
+      "geometry": {
+          "coordinates": [38.42, 9.02],
+          "type": "Point"
+      },
+      "id": "ET"
+  }, {
+      "properties": {
+          "country": "Somalia",
+          "city": "Mogadishu",
+          "tld": "so",
+          "iso3": "SOM",
+          "iso2": "SO"
+      },
+      "geometry": {
+          "coordinates": [45.22, 2.04],
+          "type": "Point"
+      },
+      "id": "SO"
+  }, {
+      "properties": {
+          "country": "Zimbabwe",
+          "city": "Harare",
+          "tld": "zw",
+          "iso3": "ZWE",
+          "iso2": "ZW"
+      },
+      "geometry": {
+          "coordinates": [31.03, -17.5],
+          "type": "Point"
+      },
+      "id": "ZW"
+  }, {
+      "properties": {
+          "country": "Saudi Arabia",
+          "city": "Riyadh",
+          "tld": "sa",
+          "iso3": "SAU",
+          "iso2": "SA"
+      },
+      "geometry": {
+          "coordinates": [46.43, 24.38],
+          "type": "Point"
+      },
+      "id": "SA"
+  }, {
+      "properties": {
+          "country": "Spain",
+          "city": "Madrid",
+          "tld": "es",
+          "iso3": "ESP",
+          "iso2": "ES"
+      },
+      "geometry": {
+          "coordinates": [-3.41, 40.24],
+          "type": "Point"
+      },
+      "id": "ES"
+  }, {
+      "properties": {
+          "country": "Eritrea",
+          "city": "Asmara",
+          "tld": "er",
+          "iso3": "ERI",
+          "iso2": "ER"
+      },
+      "geometry": {
+          "coordinates": [38.56, 15.2],
+          "type": "Point"
+      },
+      "id": "ER"
+  }, {
+      "properties": {
+          "country": "Montenegro",
+          "city": "Podgorica",
+          "tld": "me",
+          "iso3": "MNE",
+          "iso2": "ME"
+      },
+      "geometry": {
+          "coordinates": [19.16, 42.26],
+          "type": "Point"
+      },
+      "id": "ME"
+  }, {
+      "properties": {
+          "country": "Moldova",
+          "city": "Chisinau",
+          "tld": "md",
+          "iso3": "MDA",
+          "iso2": "MD"
+      },
+      "geometry": {
+          "coordinates": [28.51, 47],
+          "type": "Point"
+      },
+      "id": "MD"
+  }, {
+      "properties": {
+          "country": "Madagascar",
+          "city": "Antananarivo",
+          "tld": "mg",
+          "iso3": "MDG",
+          "iso2": "MG"
+      },
+      "geometry": {
+          "coordinates": [47.31, -18.55],
+          "type": "Point"
+      },
+      "id": "MG"
+  }, {
+      "properties": {
+          "country": "Saint Martin",
+          "city": "Marigot",
+          "tld": "mf",
+          "iso3": "MAF",
+          "iso2": "MF"
+      },
+      "geometry": {
+          "coordinates": [-63.05, 18.04],
+          "type": "Point"
+      },
+      "id": "MF"
+  }, {
+      "properties": {
+          "country": "Morocco",
+          "city": "Rabat",
+          "tld": "ma",
+          "iso3": "MAR",
+          "iso2": "MA"
+      },
+      "geometry": {
+          "coordinates": [-6.49, 34.01],
+          "type": "Point"
+      },
+      "id": "MA"
+  }, {
+      "properties": {
+          "country": "Monaco",
+          "city": "Monaco",
+          "tld": "mc",
+          "iso3": "MCO",
+          "iso2": "MC"
+      },
+      "geometry": {
+          "coordinates": [7.25, 43.44],
+          "type": "Point"
+      },
+      "id": "MC"
+  }, {
+      "properties": {
+          "country": "Uzbekistan",
+          "city": "Tashkent",
+          "tld": "uz",
+          "iso3": "UZB",
+          "iso2": "UZ"
+      },
+      "geometry": {
+          "coordinates": [69.18, 41.2],
+          "type": "Point"
+      },
+      "id": "UZ"
+  }, {
+      "properties": {
+          "country": "Myanmar",
+          "city": "Rangoon",
+          "tld": "mm",
+          "iso3": "MMR",
+          "iso2": "MM"
+      },
+      "geometry": {
+          "coordinates": [96.09, 16.48],
+          "type": "Point"
+      },
+      "id": "MM"
+  }, {
+      "properties": {
+          "country": "Mali",
+          "city": "Bamako",
+          "tld": "ml",
+          "iso3": "MLI",
+          "iso2": "ML"
+      },
+      "geometry": {
+          "coordinates": [-8, 12.39],
+          "type": "Point"
+      },
+      "id": "ML"
+  }, {
+      "properties": {
+          "country": "Macao",
+          "tld": "mo",
+          "iso3": "MAC",
+          "iso2": "MO"
+      },
+      "geometry": {
+          "coordinates": [113.33, 22.1],
+          "type": "Point"
+      },
+      "id": "MO"
+  }, {
+      "properties": {
+          "country": "Mongolia",
+          "city": "Ulaanbaatar",
+          "tld": "mn",
+          "iso3": "MNG",
+          "iso2": "MN"
+      },
+      "geometry": {
+          "coordinates": [106.55, 47.55],
+          "type": "Point"
+      },
+      "id": "MN"
+  }, {
+      "properties": {
+          "country": "Marshall Islands",
+          "city": "Majuro",
+          "tld": "mh",
+          "iso3": "MHL",
+          "iso2": "MH"
+      },
+      "geometry": {
+          "coordinates": [171.23, 7.06],
+          "type": "Point"
+      },
+      "id": "MH"
+  }, {
+      "properties": {
+          "country": "Macedonia",
+          "city": "Skopje",
+          "tld": "mk",
+          "iso3": "MKD",
+          "iso2": "MK"
+      },
+      "geometry": {
+          "coordinates": [21.26, 42],
+          "type": "Point"
+      },
+      "id": "MK"
+  }, {
+      "properties": {
+          "country": "Mauritius",
+          "city": "Port Louis",
+          "tld": "mu",
+          "iso3": "MUS",
+          "iso2": "MU"
+      },
+      "geometry": {
+          "coordinates": [57.29, -20.09],
+          "type": "Point"
+      },
+      "id": "MU"
+  }, {
+      "properties": {
+          "country": "Malta",
+          "city": "Valletta",
+          "tld": "mt",
+          "iso3": "MLT",
+          "iso2": "MT"
+      },
+      "geometry": {
+          "coordinates": [14.3, 35.53],
+          "type": "Point"
+      },
+      "id": "MT"
+  }, {
+      "properties": {
+          "country": "Malawi",
+          "city": "Lilongwe",
+          "tld": "mw",
+          "iso3": "MWI",
+          "iso2": "MW"
+      },
+      "geometry": {
+          "coordinates": [33.47, -13.59],
+          "type": "Point"
+      },
+      "id": "MW"
+  }, {
+      "properties": {
+          "country": "Maldives",
+          "city": "Male",
+          "tld": "mv",
+          "iso3": "MDV",
+          "iso2": "MV"
+      },
+      "geometry": {
+          "coordinates": [73.3, 4.1],
+          "type": "Point"
+      },
+      "id": "MV"
+  }, {
+      "properties": {
+          "country": "Northern Mariana Islands",
+          "city": "Saipan",
+          "tld": "mp",
+          "iso3": "MNP",
+          "iso2": "MP"
+      },
+      "geometry": {
+          "coordinates": [145.45, 15.12],
+          "type": "Point"
+      },
+      "id": "MP"
+  }, {
+      "properties": {
+          "country": "Montserrat",
+          "city": "Plymouth",
+          "tld": "ms",
+          "iso3": "MSR",
+          "iso2": "MS"
+      },
+      "geometry": {
+          "coordinates": [-62.13, 16.42],
+          "type": "Point"
+      },
+      "id": "MS"
+  }, {
+      "properties": {
+          "country": "Mauritania",
+          "city": "Nouakchott",
+          "tld": "mr",
+          "iso3": "MRT",
+          "iso2": "MR"
+      },
+      "geometry": {
+          "coordinates": [-16.02, 18.07],
+          "type": "Point"
+      },
+      "id": "MR"
+  }, {
+      "properties": {
+          "country": "Isle of Man",
+          "city": "Douglas",
+          "tld": "im",
+          "iso3": "IMN",
+          "iso2": "IM"
+      },
+      "geometry": {
+          "coordinates": [-4.29, 54.09],
+          "type": "Point"
+      },
+      "id": "IM"
+  }, {
+      "properties": {
+          "country": "Uganda",
+          "city": "Kampala",
+          "tld": "ug",
+          "iso3": "UGA",
+          "iso2": "UG"
+      },
+      "geometry": {
+          "coordinates": [32.25, 0.19],
+          "type": "Point"
+      },
+      "id": "UG"
+  }, {
+      "properties": {
+          "country": "Malaysia",
+          "city": "Kuala Lumpur",
+          "tld": "my",
+          "iso3": "MYS",
+          "iso2": "MY"
+      },
+      "geometry": {
+          "coordinates": [101.42, 3.1],
+          "type": "Point"
+      },
+      "id": "MY"
+  }, {
+      "properties": {
+          "country": "Mexico",
+          "city": "Mexico City",
+          "tld": "mx",
+          "iso3": "MEX",
+          "iso2": "MX"
+      },
+      "geometry": {
+          "coordinates": [-99.08, 19.26],
+          "type": "Point"
+      },
+      "id": "MX"
+  }, {
+      "properties": {
+          "country": "Israel",
+          "city": "Jerusalem",
+          "tld": "il",
+          "iso3": "ISR",
+          "iso2": "IL"
+      },
+      "geometry": {
+          "coordinates": [35.14, 31.46],
+          "type": "Point"
+      },
+      "id": "IL"
+  }, {
+      "properties": {
+          "country": "France",
+          "city": "Paris",
+          "tld": "fr",
+          "iso3": "FRA",
+          "iso2": "FR"
+      },
+      "geometry": {
+          "coordinates": [2.2, 48.52],
+          "type": "Point"
+      },
+      "id": "FR"
+  }, {
+      "properties": {
+          "country": "British Indian Ocean Territory",
+          "tld": "io",
+          "iso3": "IOT",
+          "iso2": "IO"
+      },
+      "geometry": {
+          "coordinates": [71.3, -6],
+          "type": "Point"
+      },
+      "id": "IO"
+  }, {
+      "properties": {
+          "country": "Saint Helena Ascension and Tristan da Cunha",
+          "city": "Jamestown",
+          "tld": "sh",
+          "iso3": "SHN",
+          "iso2": "SH"
+      },
+      "geometry": {
+          "coordinates": [-5.44, -15.56],
+          "type": "Point"
+      },
+      "id": "SH"
+  }, {
+      "properties": {
+          "country": "Finland",
+          "city": "Helsinki",
+          "tld": "fi",
+          "iso3": "FIN",
+          "iso2": "FI"
+      },
+      "geometry": {
+          "coordinates": [24.56, 60.1],
+          "type": "Point"
+      },
+      "id": "FI"
+  }, {
+      "properties": {
+          "country": "Fiji",
+          "city": "Suva",
+          "tld": "fj",
+          "iso3": "FJI",
+          "iso2": "FJ"
+      },
+      "geometry": {
+          "coordinates": [178.25, -18.08],
+          "type": "Point"
+      },
+      "id": "FJ"
+  }, {
+      "properties": {
+          "country": "Falkland Islands",
+          "city": "Stanley",
+          "tld": "fk",
+          "iso3": "FLK",
+          "iso2": "FK"
+      },
+      "geometry": {
+          "coordinates": [-57.51, -51.42],
+          "type": "Point"
+      },
+      "id": "FK"
+  }, {
+      "properties": {
+          "country": "Micronesia",
+          "city": "Palikir",
+          "tld": "fm",
+          "iso3": "FSM",
+          "iso2": "FM"
+      },
+      "geometry": {
+          "coordinates": [158.09, 6.55],
+          "type": "Point"
+      },
+      "id": "FM"
+  }, {
+      "properties": {
+          "country": "Faroe Islands",
+          "city": "Torshavn",
+          "tld": "fo",
+          "iso3": "FRO",
+          "iso2": "FO"
+      },
+      "geometry": {
+          "coordinates": [-6.46, 62.01],
+          "type": "Point"
+      },
+      "id": "FO"
+  }, {
+      "properties": {
+          "country": "Nicaragua",
+          "city": "Managua",
+          "tld": "ni",
+          "iso3": "NIC",
+          "iso2": "NI"
+      },
+      "geometry": {
+          "coordinates": [-86.17, 12.09],
+          "type": "Point"
+      },
+      "id": "NI"
+  }, {
+      "properties": {
+          "country": "Netherlands",
+          "city": "Amsterdam",
+          "tld": "nl",
+          "iso3": "NLD",
+          "iso2": "NL"
+      },
+      "geometry": {
+          "coordinates": [4.54, 52.23],
+          "type": "Point"
+      },
+      "id": "NL"
+  }, {
+      "properties": {
+          "country": "Norway",
+          "city": "Oslo",
+          "tld": "no",
+          "iso3": "NOR",
+          "iso2": "NO"
+      },
+      "geometry": {
+          "coordinates": [10.45, 59.55],
+          "type": "Point"
+      },
+      "id": "NO"
+  }, {
+      "properties": {
+          "country": "Namibia",
+          "city": "Windhoek",
+          "tld": "na",
+          "iso3": "NAM",
+          "iso2": "NA"
+      },
+      "geometry": {
+          "coordinates": [17.05, -22.34],
+          "type": "Point"
+      },
+      "id": "NA"
+  }, {
+      "properties": {
+          "country": "Vanuatu",
+          "city": "Port-Vila",
+          "tld": "vu",
+          "iso3": "VUT",
+          "iso2": "VU"
+      },
+      "geometry": {
+          "coordinates": [168.19, -17.44],
+          "type": "Point"
+      },
+      "id": "VU"
+  }, {
+      "properties": {
+          "country": "New Caledonia",
+          "city": "Noumea",
+          "tld": "nc",
+          "iso3": "NCL",
+          "iso2": "NC"
+      },
+      "geometry": {
+          "coordinates": [166.27, -22.16],
+          "type": "Point"
+      },
+      "id": "NC"
+  }, {
+      "properties": {
+          "country": "Niger",
+          "city": "Niamey",
+          "tld": "ne",
+          "iso3": "NER",
+          "iso2": "NE"
+      },
+      "geometry": {
+          "coordinates": [2.07, 13.31],
+          "type": "Point"
+      },
+      "id": "NE"
+  }, {
+      "properties": {
+          "country": "Norfolk Island",
+          "city": "Kingston",
+          "tld": "nf",
+          "iso3": "NFK",
+          "iso2": "NF"
+      },
+      "geometry": {
+          "coordinates": [167.58, -29.03],
+          "type": "Point"
+      },
+      "id": "NF"
+  }, {
+      "properties": {
+          "country": "Nigeria",
+          "city": "Abuja",
+          "tld": "ng",
+          "iso3": "NGA",
+          "iso2": "NG"
+      },
+      "geometry": {
+          "coordinates": [7.32, 9.05],
+          "type": "Point"
+      },
+      "id": "NG"
+  }, {
+      "properties": {
+          "country": "New Zealand",
+          "city": "Wellington",
+          "tld": "nz",
+          "iso3": "NZL",
+          "iso2": "NZ"
+      },
+      "geometry": {
+          "coordinates": [174.51, -41.28],
+          "type": "Point"
+      },
+      "id": "NZ"
+  }, {
+      "properties": {
+          "country": "Nepal",
+          "city": "Kathmandu",
+          "tld": "np",
+          "iso3": "NPL",
+          "iso2": "NP"
+      },
+      "geometry": {
+          "coordinates": [85.19, 27.43],
+          "type": "Point"
+      },
+      "id": "NP"
+  }, {
+      "properties": {
+          "country": "Nauru",
+          "tld": "nr",
+          "iso3": "NRU",
+          "iso2": "NR"
+      },
+      "geometry": {
+          "coordinates": [166.55, -0.32],
+          "type": "Point"
+      },
+      "id": "NR"
+  }, {
+      "properties": {
+          "country": "Niue",
+          "city": "Alofi",
+          "tld": "nu",
+          "iso3": "NIU",
+          "iso2": "NU"
+      },
+      "geometry": {
+          "coordinates": [-169.55, -19.01],
+          "type": "Point"
+      },
+      "id": "NU"
+  }, {
+      "properties": {
+          "country": "Cook Islands",
+          "city": "Avarua",
+          "tld": "ck",
+          "iso3": "COK",
+          "iso2": "CK"
+      },
+      "geometry": {
+          "coordinates": [-159.46, -21.12],
+          "type": "Point"
+      },
+      "id": "CK"
+  }, {
+      "properties": {
+          "country": "Ivory Coast",
+          "city": "Yamoussoukro",
+          "tld": "ci",
+          "iso3": "CIV",
+          "iso2": "CI"
+      },
+      "geometry": {
+          "coordinates": [-5.17, 6.49],
+          "type": "Point"
+      },
+      "id": "CI"
+  }, {
+      "properties": {
+          "country": "Switzerland",
+          "city": "Bern",
+          "tld": "ch",
+          "iso3": "CHE",
+          "iso2": "CH"
+      },
+      "geometry": {
+          "coordinates": [7.26, 46.57],
+          "type": "Point"
+      },
+      "id": "CH"
+  }, {
+      "properties": {
+          "country": "Colombia",
+          "city": "Bogota",
+          "tld": "co",
+          "iso3": "COL",
+          "iso2": "CO"
+      },
+      "geometry": {
+          "coordinates": [-74.05, 4.36],
+          "type": "Point"
+      },
+      "id": "CO"
+  }, {
+      "properties": {
+          "country": "China",
+          "city": "Beijing",
+          "tld": "cn",
+          "iso3": "CHN",
+          "iso2": "CN"
+      },
+      "geometry": {
+          "coordinates": [116.23, 39.55],
+          "type": "Point"
+      },
+      "id": "CN"
+  }, {
+      "properties": {
+          "country": "Cameroon",
+          "city": "Yaounde",
+          "tld": "cm",
+          "iso3": "CMR",
+          "iso2": "CM"
+      },
+      "geometry": {
+          "coordinates": [11.31, 3.52],
+          "type": "Point"
+      },
+      "id": "CM"
+  }, {
+      "properties": {
+          "country": "Chile",
+          "city": "Santiago",
+          "tld": "cl",
+          "iso3": "CHL",
+          "iso2": "CL"
+      },
+      "geometry": {
+          "coordinates": [-70.4, -33.27],
+          "type": "Point"
+      },
+      "id": "CL"
+  }, {
+      "properties": {
+          "country": "Cocos Islands",
+          "city": "West Island",
+          "tld": "cc",
+          "iso3": "CCK",
+          "iso2": "CC"
+      },
+      "geometry": {
+          "coordinates": [96.5, -12.1],
+          "type": "Point"
+      },
+      "id": "CC"
+  }, {
+      "properties": {
+          "country": "Canada",
+          "city": "Ottawa",
+          "tld": "ca",
+          "iso3": "CAN",
+          "iso2": "CA"
+      },
+      "geometry": {
+          "coordinates": [-75.42, 45.25],
+          "type": "Point"
+      },
+      "id": "CA"
+  }, {
+      "properties": {
+          "country": "Congo Republic",
+          "city": "Brazzaville",
+          "tld": "cg",
+          "iso3": "COG",
+          "iso2": "CG"
+      },
+      "geometry": {
+          "coordinates": [15.17, -4.15],
+          "type": "Point"
+      },
+      "id": "CG"
+  }, {
+      "properties": {
+          "country": "Central African Republic",
+          "city": "Bangui",
+          "tld": "cf",
+          "iso3": "CAF",
+          "iso2": "CF"
+      },
+      "geometry": {
+          "coordinates": [18.35, 4.22],
+          "type": "Point"
+      },
+      "id": "CF"
+  }, {
+      "properties": {
+          "country": "Congo Democratic Republic",
+          "city": "Kinshasa",
+          "tld": "cd",
+          "iso3": "COD",
+          "iso2": "CD"
+      },
+      "geometry": {
+          "coordinates": [15.18, -4.19],
+          "type": "Point"
+      },
+      "id": "CD"
+  }, {
+      "properties": {
+          "country": "Czech Republic",
+          "city": "Prague",
+          "tld": "cz",
+          "iso3": "CZE",
+          "iso2": "CZ"
+      },
+      "geometry": {
+          "coordinates": [14.28, 50.05],
+          "type": "Point"
+      },
+      "id": "CZ"
+  }, {
+      "properties": {
+          "country": "Cyprus",
+          "city": "Nicosia",
+          "tld": "cy",
+          "iso3": "CYP",
+          "iso2": "CY"
+      },
+      "geometry": {
+          "coordinates": [33.22, 35.1],
+          "type": "Point"
+      },
+      "id": "CY"
+  }, {
+      "properties": {
+          "country": "Christmas Island",
+          "city": "The Settlement",
+          "tld": "cx",
+          "iso3": "CXR",
+          "iso2": "CX"
+      },
+      "geometry": {
+          "coordinates": [105.43, -10.25],
+          "type": "Point"
+      },
+      "id": "CX"
+  }, {
+      "properties": {
+          "country": "Costa Rica",
+          "city": "San Jose",
+          "tld": "cr",
+          "iso3": "CRI",
+          "iso2": "CR"
+      },
+      "geometry": {
+          "coordinates": [-84.05, 9.56],
+          "type": "Point"
+      },
+      "id": "CR"
+  }, {
+      "properties": {
+          "country": "Cape Verde",
+          "city": "Praia",
+          "tld": "cv",
+          "iso3": "CPV",
+          "iso2": "CV"
+      },
+      "geometry": {
+          "coordinates": [-23.31, 14.55],
+          "type": "Point"
+      },
+      "id": "CV"
+  }, {
+      "properties": {
+          "country": "Cuba",
+          "city": "Havana",
+          "tld": "cu",
+          "iso3": "CUB",
+          "iso2": "CU"
+      },
+      "geometry": {
+          "coordinates": [-82.21, 23.07],
+          "type": "Point"
+      },
+      "id": "CU"
+  }, {
+      "properties": {
+          "country": "Swaziland",
+          "city": "Mbabane",
+          "tld": "sz",
+          "iso3": "SWZ",
+          "iso2": "SZ"
+      },
+      "geometry": {
+          "coordinates": [31.06, -26.18],
+          "type": "Point"
+      },
+      "id": "SZ"
+  }, {
+      "properties": {
+          "country": "Syria",
+          "city": "Damascus",
+          "tld": "sy",
+          "iso3": "SYR",
+          "iso2": "SY"
+      },
+      "geometry": {
+          "coordinates": [36.18, 33.3],
+          "type": "Point"
+      },
+      "id": "SY"
+  }, {
+      "properties": {
+          "country": "Kyrgyzstan",
+          "city": "Bishkek",
+          "tld": "kg",
+          "iso3": "KGZ",
+          "iso2": "KG"
+      },
+      "geometry": {
+          "coordinates": [74.36, 42.52],
+          "type": "Point"
+      },
+      "id": "KG"
+  }, {
+      "properties": {
+          "country": "Kenya",
+          "city": "Nairobi",
+          "tld": "ke",
+          "iso3": "KEN",
+          "iso2": "KE"
+      },
+      "geometry": {
+          "coordinates": [36.49, -1.17],
+          "type": "Point"
+      },
+      "id": "KE"
+  }, {
+      "properties": {
+          "country": "Suriname",
+          "city": "Paramaribo",
+          "tld": "sr",
+          "iso3": "SUR",
+          "iso2": "SR"
+      },
+      "geometry": {
+          "coordinates": [-55.1, 5.5],
+          "type": "Point"
+      },
+      "id": "SR"
+  }, {
+      "properties": {
+          "country": "Kiribati",
+          "city": "Tarawa",
+          "tld": "ki",
+          "iso3": "KIR",
+          "iso2": "KI"
+      },
+      "geometry": {
+          "coordinates": [172.58, 1.19],
+          "type": "Point"
+      },
+      "id": "KI"
+  }, {
+      "properties": {
+          "country": "Cambodia",
+          "city": "Phnom Penh",
+          "tld": "kh",
+          "iso3": "KHM",
+          "iso2": "KH"
+      },
+      "geometry": {
+          "coordinates": [104.55, 11.33],
+          "type": "Point"
+      },
+      "id": "KH"
+  }, {
+      "properties": {
+          "country": "Saint Kitts and Nevis",
+          "city": "Basseterre",
+          "tld": "kn",
+          "iso3": "KNA",
+          "iso2": "KN"
+      },
+      "geometry": {
+          "coordinates": [-62.43, 17.18],
+          "type": "Point"
+      },
+      "id": "KN"
+  }, {
+      "properties": {
+          "country": "Comoros",
+          "city": "Moroni",
+          "tld": "km",
+          "iso3": "COM",
+          "iso2": "KM"
+      },
+      "geometry": {
+          "coordinates": [43.14, -11.42],
+          "type": "Point"
+      },
+      "id": "KM"
+  }, {
+      "properties": {
+          "country": "Sao Tome and Principe",
+          "city": "Sao Tome",
+          "tld": "st",
+          "iso3": "STP",
+          "iso2": "ST"
+      },
+      "geometry": {
+          "coordinates": [6.39, 0.12],
+          "type": "Point"
+      },
+      "id": "ST"
+  }, {
+      "properties": {
+          "country": "Slovakia",
+          "city": "Bratislava",
+          "tld": "sk",
+          "iso3": "SVK",
+          "iso2": "SK"
+      },
+      "geometry": {
+          "coordinates": [17.07, 48.09],
+          "type": "Point"
+      },
+      "id": "SK"
+  }, {
+      "properties": {
+          "country": "Korea South",
+          "city": "Seoul",
+          "tld": "kr",
+          "iso3": "KOR",
+          "iso2": "KR"
+      },
+      "geometry": {
+          "coordinates": [126.59, 37.33],
+          "type": "Point"
+      },
+      "id": "KR"
+  }, {
+      "properties": {
+          "country": "Slovenia",
+          "city": "Ljubljana",
+          "tld": "si",
+          "iso3": "SVN",
+          "iso2": "SI"
+      },
+      "geometry": {
+          "coordinates": [14.31, 46.03],
+          "type": "Point"
+      },
+      "id": "SI"
+  }, {
+      "properties": {
+          "country": "Korea North",
+          "city": "Pyongyang",
+          "tld": "kp",
+          "iso3": "PRK",
+          "iso2": "KP"
+      },
+      "geometry": {
+          "coordinates": [125.45, 39.01],
+          "type": "Point"
+      },
+      "id": "KP"
+  }, {
+      "properties": {
+          "country": "Kuwait",
+          "city": "Kuwait City",
+          "tld": "kw",
+          "iso3": "KWT",
+          "iso2": "KW"
+      },
+      "geometry": {
+          "coordinates": [47.58, 29.22],
+          "type": "Point"
+      },
+      "id": "KW"
+  }, {
+      "properties": {
+          "country": "Senegal",
+          "city": "Dakar",
+          "tld": "sn",
+          "iso3": "SEN",
+          "iso2": "SN"
+      },
+      "geometry": {
+          "coordinates": [-17.26, 14.4],
+          "type": "Point"
+      },
+      "id": "SN"
+  }, {
+      "properties": {
+          "country": "San Marino",
+          "city": "San Marino",
+          "tld": "sm",
+          "iso3": "SMR",
+          "iso2": "SM"
+      },
+      "geometry": {
+          "coordinates": [12.25, 43.56],
+          "type": "Point"
+      },
+      "id": "SM"
+  }, {
+      "properties": {
+          "country": "Sierra Leone",
+          "city": "Freetown",
+          "tld": "sl",
+          "iso3": "SLE",
+          "iso2": "SL"
+      },
+      "geometry": {
+          "coordinates": [-13.15, 8.3],
+          "type": "Point"
+      },
+      "id": "SL"
+  }, {
+      "properties": {
+          "country": "Seychelles",
+          "city": "Victoria",
+          "tld": "sc",
+          "iso3": "SYC",
+          "iso2": "SC"
+      },
+      "geometry": {
+          "coordinates": [55.27, -4.38],
+          "type": "Point"
+      },
+      "id": "SC"
+  }, {
+      "properties": {
+          "country": "Kazakhstan",
+          "city": "Astana",
+          "tld": "kz",
+          "iso3": "KAZ",
+          "iso2": "KZ"
+      },
+      "geometry": {
+          "coordinates": [71.25, 51.1],
+          "type": "Point"
+      },
+      "id": "KZ"
+  }, {
+      "properties": {
+          "country": "Cayman Islands",
+          "city": "George Town",
+          "tld": "ky",
+          "iso3": "CYM",
+          "iso2": "KY"
+      },
+      "geometry": {
+          "coordinates": [-81.23, 19.18],
+          "type": "Point"
+      },
+      "id": "KY"
+  }, {
+      "properties": {
+          "country": "Singapore",
+          "city": "Singapore",
+          "tld": "sg",
+          "iso3": "SGP",
+          "iso2": "SG"
+      },
+      "geometry": {
+          "coordinates": [103.51, 1.17],
+          "type": "Point"
+      },
+      "id": "SG"
+  }, {
+      "properties": {
+          "country": "Sweden",
+          "city": "Stockholm",
+          "tld": "se",
+          "iso3": "SWE",
+          "iso2": "SE"
+      },
+      "geometry": {
+          "coordinates": [18.03, 59.2],
+          "type": "Point"
+      },
+      "id": "SE"
+  }, {
+      "properties": {
+          "country": "Sudan",
+          "city": "Khartoum",
+          "tld": "sd",
+          "iso3": "SDN",
+          "iso2": "SD"
+      },
+      "geometry": {
+          "coordinates": [32.32, 15.36],
+          "type": "Point"
+      },
+      "id": "SD"
+  }, {
+      "properties": {
+          "country": "Dominican Republic",
+          "city": "Santo Domingo",
+          "tld": "do",
+          "iso3": "DOM",
+          "iso2": "DO"
+      },
+      "geometry": {
+          "coordinates": [-69.54, 18.28],
+          "type": "Point"
+      },
+      "id": "DO"
+  }, {
+      "properties": {
+          "country": "Dominica",
+          "city": "Roseau",
+          "tld": "dm",
+          "iso3": "DMA",
+          "iso2": "DM"
+      },
+      "geometry": {
+          "coordinates": [-61.24, 15.18],
+          "type": "Point"
+      },
+      "id": "DM"
+  }, {
+      "properties": {
+          "country": "Djibouti",
+          "city": "Djibouti",
+          "tld": "dj",
+          "iso3": "DJI",
+          "iso2": "DJ"
+      },
+      "geometry": {
+          "coordinates": [43.09, 11.35],
+          "type": "Point"
+      },
+      "id": "DJ"
+  }, {
+      "properties": {
+          "country": "Denmark",
+          "city": "Copenhagen",
+          "tld": "dk",
+          "iso3": "DNK",
+          "iso2": "DK"
+      },
+      "geometry": {
+          "coordinates": [12.35, 55.4],
+          "type": "Point"
+      },
+      "id": "DK"
+  }, {
+      "properties": {
+          "country": "British Virgin Islands",
+          "city": "Road Town",
+          "tld": "vg",
+          "iso3": "VGB",
+          "iso2": "VG"
+      },
+      "geometry": {
+          "coordinates": [-64.37, 18.27],
+          "type": "Point"
+      },
+      "id": "VG"
+  }, {
+      "properties": {
+          "country": "Germany",
+          "city": "Berlin",
+          "tld": "de",
+          "iso3": "DEU",
+          "iso2": "DE"
+      },
+      "geometry": {
+          "coordinates": [13.24, 52.31],
+          "type": "Point"
+      },
+      "id": "DE"
+  }, {
+      "properties": {
+          "country": "Yemen",
+          "city": "Sanaa",
+          "tld": "ye",
+          "iso3": "YEM",
+          "iso2": "YE"
+      },
+      "geometry": {
+          "coordinates": [44.12, 15.21],
+          "type": "Point"
+      },
+      "id": "YE"
+  }, {
+      "properties": {
+          "country": "Algeria",
+          "city": "Algiers",
+          "tld": "dz",
+          "iso3": "DZA",
+          "iso2": "DZ"
+      },
+      "geometry": {
+          "coordinates": [3.03, 36.45],
+          "type": "Point"
+      },
+      "id": "DZ"
+  }, {
+      "properties": {
+          "country": "United States",
+          "city": "Washington, DC",
+          "tld": "us",
+          "iso3": "USA",
+          "iso2": "US"
+      },
+      "geometry": {
+          "coordinates": [-77.02, 38.53],
+          "type": "Point"
+      },
+      "id": "US"
+  }, {
+      "properties": {
+          "country": "Uruguay",
+          "city": "Montevideo",
+          "tld": "uy",
+          "iso3": "URY",
+          "iso2": "UY"
+      },
+      "geometry": {
+          "coordinates": [-56.11, -34.53],
+          "type": "Point"
+      },
+      "id": "UY"
+  }, {
+      "properties": {
+          "country": "Mayotte",
+          "city": "Mamoudzou",
+          "tld": "yt",
+          "iso3": "MYT",
+          "iso2": "YT"
+      },
+      "geometry": {
+          "coordinates": [45.13, -12.46],
+          "type": "Point"
+      },
+      "id": "YT"
+  }, {
+      "properties": {
+          "country": "Lebanon",
+          "city": "Beirut",
+          "tld": "lb",
+          "iso3": "LBN",
+          "iso2": "LB"
+      },
+      "geometry": {
+          "coordinates": [35.3, 33.52],
+          "type": "Point"
+      },
+      "id": "LB"
+  }, {
+      "properties": {
+          "country": "Saint Lucia",
+          "city": "Castries",
+          "tld": "lc",
+          "iso3": "LCA",
+          "iso2": "LC"
+      },
+      "geometry": {
+          "coordinates": [-61, 14.01],
+          "type": "Point"
+      },
+      "id": "LC"
+  }, {
+      "properties": {
+          "country": "Laos",
+          "city": "Vientiane",
+          "tld": "la",
+          "iso3": "LAO",
+          "iso2": "LA"
+      },
+      "geometry": {
+          "coordinates": [102.36, 17.58],
+          "type": "Point"
+      },
+      "id": "LA"
+  }, {
+      "properties": {
+          "country": "Tuvalu",
+          "city": "Funafuti",
+          "tld": "tv",
+          "iso3": "TUV",
+          "iso2": "TV"
+      },
+      "geometry": {
+          "coordinates": [179.12, -8.3],
+          "type": "Point"
+      },
+      "id": "TV"
+  }, {
+      "properties": {
+          "country": "Taiwan",
+          "city": "Taipei",
+          "tld": "tw",
+          "iso3": "TWN",
+          "iso2": "TW"
+      },
+      "geometry": {
+          "coordinates": [121.3, 25.03],
+          "type": "Point"
+      },
+      "id": "TW"
+  }, {
+      "properties": {
+          "country": "Trinidad and Tobago",
+          "city": "Port-of-Spain",
+          "tld": "tt",
+          "iso3": "TTO",
+          "iso2": "TT"
+      },
+      "geometry": {
+          "coordinates": [-61.31, 10.39],
+          "type": "Point"
+      },
+      "id": "TT"
+  }, {
+      "properties": {
+          "country": "Turkey",
+          "city": "Ankara",
+          "tld": "tr",
+          "iso3": "TUR",
+          "iso2": "TR"
+      },
+      "geometry": {
+          "coordinates": [32.52, 39.56],
+          "type": "Point"
+      },
+      "id": "TR"
+  }, {
+      "properties": {
+          "country": "Sri Lanka",
+          "city": "Colombo",
+          "tld": "lk",
+          "iso3": "LKA",
+          "iso2": "LK"
+      },
+      "geometry": {
+          "coordinates": [79.51, 6.56],
+          "type": "Point"
+      },
+      "id": "LK"
+  }, {
+      "properties": {
+          "country": "Liechtenstein",
+          "city": "Vaduz",
+          "tld": "li",
+          "iso3": "LIE",
+          "iso2": "LI"
+      },
+      "geometry": {
+          "coordinates": [9.31, 47.08],
+          "type": "Point"
+      },
+      "id": "LI"
+  }, {
+      "properties": {
+          "country": "Latvia",
+          "city": "Riga",
+          "tld": "lv",
+          "iso3": "LVA",
+          "iso2": "LV"
+      },
+      "geometry": {
+          "coordinates": [24.06, 56.57],
+          "type": "Point"
+      },
+      "id": "LV"
+  }, {
+      "properties": {
+          "country": "Tonga",
+          "city": "Nuku'alofa",
+          "tld": "to",
+          "iso3": "TON",
+          "iso2": "TO"
+      },
+      "geometry": {
+          "coordinates": [-175.12, -21.08],
+          "type": "Point"
+      },
+      "id": "TO"
+  }, {
+      "properties": {
+          "country": "Lithuania",
+          "city": "Vilnius",
+          "tld": "lt",
+          "iso3": "LTU",
+          "iso2": "LT"
+      },
+      "geometry": {
+          "coordinates": [25.19, 54.41],
+          "type": "Point"
+      },
+      "id": "LT"
+  }, {
+      "properties": {
+          "country": "Luxembourg",
+          "city": "Luxembourg",
+          "tld": "lu",
+          "iso3": "LUX",
+          "iso2": "LU"
+      },
+      "geometry": {
+          "coordinates": [6.07, 49.36],
+          "type": "Point"
+      },
+      "id": "LU"
+  }, {
+      "properties": {
+          "country": "Liberia",
+          "city": "Monrovia",
+          "tld": "lr",
+          "iso3": "LBR",
+          "iso2": "LR"
+      },
+      "geometry": {
+          "coordinates": [-10.48, 6.18],
+          "type": "Point"
+      },
+      "id": "LR"
+  }, {
+      "properties": {
+          "country": "Lesotho",
+          "city": "Maseru",
+          "tld": "ls",
+          "iso3": "LSO",
+          "iso2": "LS"
+      },
+      "geometry": {
+          "coordinates": [27.29, -29.19],
+          "type": "Point"
+      },
+      "id": "LS"
+  }, {
+      "properties": {
+          "country": "Thailand",
+          "city": "Bangkok",
+          "tld": "th",
+          "iso3": "THA",
+          "iso2": "TH"
+      },
+      "geometry": {
+          "coordinates": [100.31, 13.45],
+          "type": "Point"
+      },
+      "id": "TH"
+  }, {
+      "properties": {
+          "country": "French Southern Territories",
+          "tld": "tf",
+          "iso3": "ATF",
+          "iso2": "TF"
+      },
+      "geometry": {
+          "coordinates": [77.32, -37.5],
+          "type": "Point"
+      },
+      "id": "TF"
+  }, {
+      "properties": {
+          "country": "Togo",
+          "city": "Lome",
+          "tld": "tg",
+          "iso3": "TGO",
+          "iso2": "TG"
+      },
+      "geometry": {
+          "coordinates": [1.13, 6.08],
+          "type": "Point"
+      },
+      "id": "TG"
+  }, {
+      "properties": {
+          "country": "Chad",
+          "city": "N'Djamena",
+          "tld": "td",
+          "iso3": "TCD",
+          "iso2": "TD"
+      },
+      "geometry": {
+          "coordinates": [15.02, 12.06],
+          "type": "Point"
+      },
+      "id": "TD"
+  }, {
+      "properties": {
+          "country": "Turks and Caicos Islands",
+          "city": "Grand Turk",
+          "tld": "tc",
+          "iso3": "TCA",
+          "iso2": "TC"
+      },
+      "geometry": {
+          "coordinates": [-71.08, 21.28],
+          "type": "Point"
+      },
+      "id": "TC"
+  }, {
+      "properties": {
+          "country": "Libya",
+          "city": "Tripoli",
+          "tld": "ly",
+          "iso3": "LBY",
+          "iso2": "LY"
+      },
+      "geometry": {
+          "coordinates": [13.1, 32.53],
+          "type": "Point"
+      },
+      "id": "LY"
+  }, {
+      "properties": {
+          "country": "Holy See",
+          "city": "Vatican City",
+          "tld": "va",
+          "iso3": "VAT",
+          "iso2": "VA"
+      },
+      "geometry": {
+          "coordinates": [12.27, 41.54],
+          "type": "Point"
+      },
+      "id": "VA"
+  }, {
+      "properties": {
+          "country": "Saint Vincent and the Grenadines",
+          "city": "Kingstown",
+          "tld": "vc",
+          "iso3": "VCT",
+          "iso2": "VC"
+      },
+      "geometry": {
+          "coordinates": [-61.14, 13.09],
+          "type": "Point"
+      },
+      "id": "VC"
+  }, {
+      "properties": {
+          "country": "United Arab Emirates",
+          "city": "Abu Dhabi",
+          "tld": "ae",
+          "iso3": "ARE",
+          "iso2": "AE"
+      },
+      "geometry": {
+          "coordinates": [54.22, 24.28],
+          "type": "Point"
+      },
+      "id": "AE"
+  }, {
+      "properties": {
+          "country": "Andorra",
+          "city": "Andorra la Vella",
+          "tld": "ad",
+          "iso3": "AND",
+          "iso2": "AD"
+      },
+      "geometry": {
+          "coordinates": [1.31, 42.3],
+          "type": "Point"
+      },
+      "id": "AD"
+  }, {
+      "properties": {
+          "country": "Antigua and Barbuda",
+          "city": "Saint John's",
+          "tld": "ag",
+          "iso3": "ATG",
+          "iso2": "AG"
+      },
+      "geometry": {
+          "coordinates": [-61.51, 17.07],
+          "type": "Point"
+      },
+      "id": "AG"
+  }, {
+      "properties": {
+          "country": "Afghanistan",
+          "city": "Kabul",
+          "tld": "af",
+          "iso3": "AFG",
+          "iso2": "AF"
+      },
+      "geometry": {
+          "coordinates": [69.11, 34.31],
+          "type": "Point"
+      },
+      "id": "AF"
+  }, {
+      "properties": {
+          "country": "Anguilla",
+          "city": "The Valley",
+          "tld": "ai",
+          "iso3": "AIA",
+          "iso2": "AI"
+      },
+      "geometry": {
+          "coordinates": [-63.03, 18.13],
+          "type": "Point"
+      },
+      "id": "AI"
+  }, {
+      "properties": {
+          "country": "Virgin Islands",
+          "city": "Charlotte Amalie",
+          "tld": "vi",
+          "iso3": "VIR",
+          "iso2": "VI"
+      },
+      "geometry": {
+          "coordinates": [-64.56, 18.21],
+          "type": "Point"
+      },
+      "id": "VI"
+  }, {
+      "properties": {
+          "country": "Iceland",
+          "city": "Reykjavik",
+          "tld": "is",
+          "iso3": "ISL",
+          "iso2": "IS"
+      },
+      "geometry": {
+          "coordinates": [-21.57, 64.09],
+          "type": "Point"
+      },
+      "id": "IS"
+  }, {
+      "properties": {
+          "country": "Iran",
+          "city": "Tehran",
+          "tld": "ir",
+          "iso3": "IRN",
+          "iso2": "IR"
+      },
+      "geometry": {
+          "coordinates": [51.25, 35.4],
+          "type": "Point"
+      },
+      "id": "IR"
+  }, {
+      "properties": {
+          "country": "Armenia",
+          "city": "Yerevan",
+          "tld": "am",
+          "iso3": "ARM",
+          "iso2": "AM"
+      },
+      "geometry": {
+          "coordinates": [44.3, 40.1],
+          "type": "Point"
+      },
+      "id": "AM"
+  }, {
+      "properties": {
+          "country": "Albania",
+          "city": "Tirana",
+          "tld": "al",
+          "iso3": "ALB",
+          "iso2": "AL"
+      },
+      "geometry": {
+          "coordinates": [19.49, 41.19],
+          "type": "Point"
+      },
+      "id": "AL"
+  }, {
+      "properties": {
+          "country": "Angola",
+          "city": "Luanda",
+          "tld": "ao",
+          "iso3": "AGO",
+          "iso2": "AO"
+      },
+      "geometry": {
+          "coordinates": [13.14, -8.5],
+          "type": "Point"
+      },
+      "id": "AO"
+  }, {
+      "properties": {
+          "country": "Netherlands Antilles",
+          "city": "Willemstad",
+          "tld": "an",
+          "iso3": "ANT",
+          "iso2": "AN"
+      },
+      "geometry": {
+          "coordinates": [-68.56, 12.06],
+          "type": "Point"
+      },
+      "id": "AN"
+  }, {
+      "properties": {
+          "country": "Antarctica",
+          "tld": "aq",
+          "iso3": "ATA",
+          "iso2": "AQ"
+      },
+      "geometry": {
+          "coordinates": [0, -90],
+          "type": "Point"
+      },
+      "id": "AQ"
+  }, {
+      "properties": {
+          "country": "Asia &amp; Pacific",
+          "tld": "asia",
+          "iso3": "N/A",
+          "iso2": "AP"
+      },
+      "geometry": {
+          "coordinates": [0, 0],
+          "type": "Point"
+      },
+      "id": "AP"
+  }, {
+      "properties": {
+          "country": "American Samoa",
+          "city": "Pago Pago",
+          "tld": "as",
+          "iso3": "ASM",
+          "iso2": "AS"
+      },
+      "geometry": {
+          "coordinates": [-170.42, -14.16],
+          "type": "Point"
+      },
+      "id": "AS"
+  }, {
+      "properties": {
+          "country": "Argentina",
+          "city": "Buenos Aires",
+          "tld": "ar",
+          "iso3": "ARG",
+          "iso2": "AR"
+      },
+      "geometry": {
+          "coordinates": [-58.4, -34.36],
+          "type": "Point"
+      },
+      "id": "AR"
+  }, {
+      "properties": {
+          "country": "Australia",
+          "city": "Canberra",
+          "tld": "au",
+          "iso3": "AUS",
+          "iso2": "AU"
+      },
+      "geometry": {
+          "coordinates": [149.13, -35.17],
+          "type": "Point"
+      },
+      "id": "AU"
+  }, {
+      "properties": {
+          "country": "Austria",
+          "city": "Vienna",
+          "tld": "at",
+          "iso3": "AUT",
+          "iso2": "AT"
+      },
+      "geometry": {
+          "coordinates": [16.22, 48.12],
+          "type": "Point"
+      },
+      "id": "AT"
+  }, {
+      "properties": {
+          "country": "Aruba",
+          "city": "Oranjestad",
+          "tld": "aw",
+          "iso3": "ABW",
+          "iso2": "AW"
+      },
+      "geometry": {
+          "coordinates": [-70.02, 12.31],
+          "type": "Point"
+      },
+      "id": "AW"
+  }, {
+      "properties": {
+          "country": "India",
+          "city": "New Delhi",
+          "tld": "in",
+          "iso3": "IND",
+          "iso2": "IN"
+      },
+      "geometry": {
+          "coordinates": [77.12, 28.36],
+          "type": "Point"
+      },
+      "id": "IN"
+  }, {
+      "properties": {
+          "country": "Tanzania",
+          "city": "Dar es Salaam",
+          "tld": "tz",
+          "iso3": "TZA",
+          "iso2": "TZ"
+      },
+      "geometry": {
+          "coordinates": [39.17, -6.48],
+          "type": "Point"
+      },
+      "id": "TZ"
+  }, {
+      "properties": {
+          "country": "Azerbaijan",
+          "city": "Baku",
+          "tld": "az",
+          "iso3": "AZE",
+          "iso2": "AZ"
+      },
+      "geometry": {
+          "coordinates": [49.52, 40.23],
+          "type": "Point"
+      },
+      "id": "AZ"
+  }, {
+      "properties": {
+          "country": "Ireland",
+          "city": "Dublin",
+          "tld": "ie",
+          "iso3": "IRL",
+          "iso2": "IE"
+      },
+      "geometry": {
+          "coordinates": [-6.14, 53.19],
+          "type": "Point"
+      },
+      "id": "IE"
+  }, {
+      "properties": {
+          "country": "Indonesia",
+          "city": "Jakarta",
+          "tld": "id",
+          "iso3": "IDN",
+          "iso2": "ID"
+      },
+      "geometry": {
+          "coordinates": [106.49, -6.1],
+          "type": "Point"
+      },
+      "id": "ID"
+  }, {
+      "properties": {
+          "country": "Ukraine",
+          "city": "Kiew",
+          "tld": "ua",
+          "iso3": "UKR",
+          "iso2": "UA"
+      },
+      "geometry": {
+          "coordinates": [30.554, 50.441],
+          "type": "Point"
+      },
+      "id": "UA"
+  }, {
+      "properties": {
+          "country": "Qatar",
+          "city": "Doha",
+          "tld": "qa",
+          "iso3": "QAT",
+          "iso2": "QA"
+      },
+      "geometry": {
+          "coordinates": [51.32, 25.17],
+          "type": "Point"
+      },
+      "id": "QA"
+  }, {
+      "properties": {
+          "country": "Mozambique",
+          "city": "Maputo",
+          "tld": "mz",
+          "iso3": "MOZ",
+          "iso2": "MZ"
+      },
+      "geometry": {
+          "coordinates": [32.35, -25.57],
+          "type": "Point"
+      },
+      "id": "MZ"
+  }]
+}

--- a/client/src/components/map/layers/ring-layer/component.tsx
+++ b/client/src/components/map/layers/ring-layer/component.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+
+import { ScatterplotLayer } from "@deck.gl/layers/typed";
+import { Layer } from "deck.gl/typed";
+import { RasterSource } from "mapbox-gl";
+
+import { useGetCategories } from "@/types/generated/category";
+
+import GEOJSON from "@/components/map/layers/ring-layer/capitals.json";
+import RingExtension from "@/components/map/layers/ring-layer/extension";
+import { useDeckMapboxOverlay } from "@/components/map/provider";
+
+// const GEOSJON = {
+//   type: "FeatureCollection",
+//   features: [
+//     {
+//       type: "Feature",
+//       properties: {
+//         name: "Tokyo",
+//         country: "Japan",
+//       },
+//       geometry: {
+//         type: "Point",
+//         coordinates: [139.6917, 35.6895],
+//       },
+//     },
+//     {
+//       type: "Feature",
+//       properties: {
+//         name: "Paris",
+//         country: "France",
+//       },
+//       geometry: {
+//         type: "Point",
+//         coordinates: [2.3522, 48.8566],
+//       },
+//     },
+//     {
+//       type: "Feature",
+//       properties: {
+//         name: "Washington, D.C.",
+//         country: "United States",
+//       },
+//       geometry: {
+//         type: "Point",
+//         coordinates: [-77.0369, 38.8951],
+//       },
+//     },
+//     {
+//       type: "Feature",
+//       properties: {
+//         name: "Cape Town",
+//         country: "South Africa",
+//       },
+//       geometry: {
+//         type: "Point",
+//         coordinates: [18.4233, -33.918861],
+//       },
+//     },
+//   ],
+// } satisfies FeatureCollection;
+
+export interface RingLayerComponentProps {
+  id: string;
+  beforeId: string;
+  source: RasterSource;
+  opacity: number;
+  visibility: boolean;
+  decodeFunction: string;
+  decodeParams: Record<string, unknown>;
+}
+
+export default function RingLayerComponent({ id, visibility, opacity }: RingLayerComponentProps) {
+  const { data } = useGetCategories();
+  console.info(data);
+
+  const layer1: Layer = useMemo(() => {
+    return new ScatterplotLayer({
+      id,
+      data: GEOJSON.features,
+      opacity: opacity ?? 1,
+      visible: visibility ?? true,
+      getPosition: (d) => d.geometry.coordinates,
+      getFillColor: (d) => [
+        (1 - Math.abs(d.geometry.coordinates[1] / 90)) * 255,
+        (1 - Math.abs(d.geometry.coordinates[0] / 180)) * 255,
+        0,
+      ],
+      getRadius: 2,
+      radiusUnits: "pixels",
+      pickable: true,
+      onClick: (props) => {
+        console.info(props);
+      },
+    });
+  }, [id, opacity, visibility]);
+
+  const layer2: Layer = useMemo(() => {
+    return new ScatterplotLayer({
+      id,
+      data: GEOJSON.features,
+      opacity: opacity ?? 1,
+      visible: visibility ?? true,
+      getPosition: (d) => d.geometry.coordinates,
+      getFillColor: [125, 125, 125],
+      getRandom: () => Math.random(),
+      getRadius: 8,
+      radiusUnits: "pixels",
+      extensions: [new RingExtension()],
+    });
+  }, [id, opacity, visibility]);
+
+  useDeckMapboxOverlay({
+    id,
+    did: "2",
+    layer: layer2,
+  });
+
+  useDeckMapboxOverlay({
+    id,
+    did: "1",
+    layer: layer1,
+  });
+
+  return null;
+}

--- a/client/src/components/map/layers/ring-layer/extension.tsx
+++ b/client/src/components/map/layers/ring-layer/extension.tsx
@@ -1,0 +1,121 @@
+import { Layer, LayerExtension, LayerContext } from "@deck.gl/core/typed";
+
+type RingExtensionType = Layer<{
+  decodeFunction: string;
+  decodeParams: Record<string, unknown>;
+  zoom: number;
+}>;
+
+export default class RingExtension extends LayerExtension {
+  startTime = performance.now() / 1000;
+
+  getShaders(this: RingExtensionType) {
+    return {
+      inject: {
+        // VERTEX SHADER
+        "vs:#decl": /*glsl*/ `
+          uniform float uTime;
+          uniform float uStartTime;
+
+          attribute float aRandom;
+
+          varying float vRandom;
+          varying vec3 vWorldPosition;
+        `,
+        "vs:#main-end": /*glsl*/ `
+          vRandom = aRandom;
+          vWorldPosition = geometry.worldPosition;
+        `,
+        "vs:DECKGL_FILTER_SIZE": /*glsl*/ `
+          float timespan = 1.5 + aRandom;
+          float wave = smoothstep(0.0, 1.0, fract((uTime - (uStartTime + (aRandom * 10.0))) / timespan));
+
+          // Based on world positions
+          // float a = clamp(abs((vWorldPosition.y * 1.5 / 90.0)), 0.0, 1.0);
+          // float a = clamp(abs(((vWorldPosition.y - 40.0) * 5.0) / 90.0), 0.0, 1.0);
+
+          // Based on current viewport
+          // We dont't have access to the geometry.position.y because at this moment the position in not projected yet
+          vec4 common_pos = project_position(vec4(geometry.worldPosition, 1.0));
+          vec4 pos = project_common_position_to_clipspace(common_pos);
+          float ax = abs(pos.x);
+          float ay = abs(pos.y);
+          float a = clamp((ax + ay) / 2.0, 0.0, 1.0);
+
+          if ((uStartTime + (aRandom * 10.0)) > uTime) {
+            size = vec3(0.0);
+          } else {
+            size *= wave * (1.0 + (3.0 * (1.0 - a)));
+          }
+        `,
+
+        // FRAGMENT SHADER
+        "fs:#decl": /*glsl*/ `
+          uniform float uTime;
+          uniform float uStartTime;
+
+          varying float vRandom;
+          varying vec3 vWorldPosition;
+        `,
+
+        "fs:DECKGL_FILTER_COLOR": /*glsl*/ `
+          float timespan = 1.5 + vRandom;
+          float wave = smoothstep(0.0, 1.0, fract((uTime - (uStartTime + (vRandom * 10.0))) / timespan));
+          // float wave = sin(uTime * 2.0) * 0.5 + 0.5;
+
+          float r = 1.0 - abs(vWorldPosition.y / 90.0);
+          float g = 1.0 - abs(vWorldPosition.x / 180.0);
+          float circle = (geometry.uv.x * geometry.uv.x + geometry.uv.y * geometry.uv.y);
+          vec4 color1 = vec4(r, g, 0.0, 0.6);
+          vec4 color2 = vec4(r, g, 0.0, 0.8);
+
+          color = mix(color1, color2, circle + wave);
+          color.a = 1. - wave;
+        `,
+      },
+    };
+  }
+
+  draw(this: Layer, params: Record<string, unknown>, extension: this): void {
+    for (const model of this.getModels()) {
+      model.setUniforms({
+        uTime: performance.now() / 1000,
+        uStartTime: extension.startTime,
+      });
+    }
+
+    this.setNeedsRedraw();
+
+    super.draw(params, extension);
+  }
+
+  initializeState(this: Layer, context: LayerContext, extension: this): void {
+    super.initializeState(context, extension);
+
+    const attributeManager = this.getAttributeManager();
+
+    attributeManager!.addInstanced({
+      random: {
+        size: 1,
+        accessor: "getRandom",
+        shaderAttributes: {
+          aRandom: {
+            vertexOffset: 0,
+          },
+        },
+      },
+    });
+  }
+
+  // updateState(this: RingExtensionType) {
+  //   // const { decodeParams = {}, zoom } = this.props;
+
+  //   for (const model of this.getModels()) {
+  //     model.setUniforms({
+  //       uTime: performance.now() / 1000,
+  //     });
+  //   }
+  // }
+}
+
+RingExtension.extensionName = "RingExtension";

--- a/client/src/components/map/layers/ring-layer/extension.tsx
+++ b/client/src/components/map/layers/ring-layer/extension.tsx
@@ -27,11 +27,12 @@ export default class RingExtension extends LayerExtension {
           vWorldPosition = geometry.worldPosition;
         `,
         "vs:DECKGL_FILTER_SIZE": /*glsl*/ `
+          vWorldPosition = geometry.worldPosition;
           float timespan = 1.5 + aRandom;
           float wave = smoothstep(0.0, 1.0, fract((uTime - (uStartTime + (aRandom * 10.0))) / timespan));
 
           // Based on world positions
-          // float a = clamp(abs((vWorldPosition.y * 1.5 / 90.0)), 0.0, 1.0);
+          // float a = clamp(abs((vWorldPosition.y / 90.0)), 0.0, 1.0);
           // float a = clamp(abs(((vWorldPosition.y - 40.0) * 5.0) / 90.0), 0.0, 1.0);
 
           // Based on current viewport

--- a/client/src/components/map/layers/ring-layer/index.tsx
+++ b/client/src/components/map/layers/ring-layer/index.tsx
@@ -1,0 +1,78 @@
+import { GeoBoundingBox, TileLayer } from "@deck.gl/geo-layers/typed";
+import { BitmapLayer } from "@deck.gl/layers/typed";
+import GL from "@luma.gl/constants";
+import { RasterSource } from "mapbox-gl";
+
+import { LayerProps } from "@/types/layers";
+
+import RingExtension from "@/components/map/layers/ring-layer/extension";
+
+export interface RingLayerProps extends LayerProps {
+  source: RasterSource;
+  opacity: number;
+  visibility: boolean;
+  decodeFunction: string;
+  decodeParams: Record<string, unknown>;
+}
+
+class RingLayer {
+  constructor({ id, source, visibility, opacity, decodeFunction, decodeParams }: RingLayerProps) {
+    return new TileLayer<
+      unknown,
+      {
+        decodeFunction: RingLayerProps["decodeFunction"];
+        decodeParams: RingLayerProps["decodeParams"];
+      }
+    >({
+      id,
+      data: source.tiles,
+      tileSize: source.tileSize ?? 256,
+      minZoom: source.minzoom,
+      maxZoom: source.maxzoom,
+      visible: visibility ?? true,
+      opacity: opacity ?? 1,
+      refinementStrategy: "never",
+      decodeFunction,
+      decodeParams,
+      renderSubLayers: (subLayer) => {
+        const {
+          id: subLayerId,
+          data: subLayerData,
+          tile: subLayerTile,
+          visible: subLayerVisible,
+          opacity: subLayerOpacity,
+        } = subLayer;
+
+        const { zoom } = subLayerTile;
+        const { west, south, east, north } = subLayerTile.bbox as GeoBoundingBox;
+
+        if (subLayerData) {
+          return new BitmapLayer({
+            id: subLayerId,
+            image: subLayerData,
+            bounds: [west, south, east, north],
+            textureParameters: {
+              [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
+              [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
+              [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
+              [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE,
+            },
+            zoom,
+            visible: subLayerVisible,
+            opacity: subLayerOpacity,
+            decodeParams,
+            decodeFunction,
+            extensions: [new RingExtension()],
+            updateTriggers: {
+              decodeParams,
+              decodeFunction,
+            },
+          });
+        }
+        return null;
+      },
+    });
+  }
+}
+
+export default RingLayer;

--- a/client/src/components/map/provider.tsx
+++ b/client/src/components/map/provider.tsx
@@ -109,6 +109,7 @@ export const useDeckMapboxOverlay = ({ id, layer }: { id: string; layer: Layer |
     if (!layer) return;
     // Give the map a chance to load the background layer before adding the Deck layer
     setTimeout(() => {
+      // https://github.com/visgl/deck.gl/blob/c2ba79b08b0ea807c6779d8fe1aaa307ebc22f91/modules/mapbox/src/resolve-layers.ts#L66
       // @ts-expect-error not typed
       addLayer(layer.clone({ id: i, beforeId: id }));
     }, 10);

--- a/client/src/components/map/provider.tsx
+++ b/client/src/components/map/provider.tsx
@@ -1,11 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 "use client";
 
-import { createContext, PropsWithChildren, useCallback, useContext, useMemo, useRef } from "react";
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 
 import { useControl, useMap } from "react-map-gl";
 
 import { MapboxOverlay, MapboxOverlayProps } from "@deck.gl/mapbox/typed";
+import { Layer } from "deck.gl/typed";
 
 interface DeckMapboxOverlayContext {
   addLayer: (layer: any) => void;
@@ -90,4 +99,27 @@ export const useDeckMapboxOverlayContext = () => {
   }
 
   return context;
+};
+
+export const useDeckMapboxOverlay = ({ id, layer }: { id: string; layer: Layer | null }) => {
+  const i = `${id}-deck`;
+  const { addLayer, removeLayer } = useDeckMapboxOverlayContext();
+
+  useEffect(() => {
+    if (!layer) return;
+    // Give the map a chance to load the background layer before adding the Deck layer
+    setTimeout(() => {
+      // @ts-expect-error not typed
+      addLayer(layer.clone({ id: i, beforeId: id }));
+    }, 10);
+  }, [i, id, layer, addLayer]);
+
+  useEffect(() => {
+    if (!layer) return;
+    return () => {
+      removeLayer(i);
+    };
+  }, [i, removeLayer]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { addLayer, removeLayer };
 };

--- a/client/src/components/map/provider.tsx
+++ b/client/src/components/map/provider.tsx
@@ -101,8 +101,16 @@ export const useDeckMapboxOverlayContext = () => {
   return context;
 };
 
-export const useDeckMapboxOverlay = ({ id, layer }: { id: string; layer: Layer | null }) => {
-  const i = `${id}-deck`;
+export const useDeckMapboxOverlay = ({
+  id,
+  layer,
+  did,
+}: {
+  id: string;
+  layer: Layer | null;
+  did?: string;
+}) => {
+  const i = did ?? `${id}-deck`;
   const { addLayer, removeLayer } = useDeckMapboxOverlayContext();
 
   useEffect(() => {

--- a/client/src/constants/datasets.ts
+++ b/client/src/constants/datasets.ts
@@ -1,4 +1,4 @@
-export function GET_CATEGORIES_OPTIONS(search?: string) {
+export function GET_CATEGORIES_OPTIONS(search?: string, publicationState?: string) {
   return {
     "pagination[pageSize]": 100,
     populate: "datasets",
@@ -12,10 +12,15 @@ export function GET_CATEGORIES_OPTIONS(search?: string) {
         },
       }),
     },
+    publicationState: publicationState || "live",
   };
 }
 
-export function GET_DATASETS_OPTIONS(search?: string, categoryId?: number) {
+export function GET_DATASETS_OPTIONS(
+  search?: string,
+  categoryId?: number,
+  publicationState?: string,
+) {
   return {
     "pagination[pageSize]": 100,
     filters: {
@@ -28,5 +33,6 @@ export function GET_DATASETS_OPTIONS(search?: string, categoryId?: number) {
     },
     populate: "*",
     sort: "name:asc",
+    publicationState: publicationState || "live",
   };
 }

--- a/client/src/containers/countries/popup.tsx
+++ b/client/src/containers/countries/popup.tsx
@@ -42,11 +42,13 @@ const CountryPopup = () => {
 
   const COUNTRY = countriesData?.data?.find((c) => c.attributes?.iso3 === country);
 
-  const TABLE_COLUMNS_DATA = [country, ...countriesComparison].map((c) => {
-    const C = countriesData?.data?.find((c1) => c1.attributes?.iso3 === c);
+  const TABLE_COLUMNS_DATA = [country, ...countriesComparison]
+    .map((c) => {
+      const C = countriesData?.data?.find((c1) => c1.attributes?.iso3 === c);
 
-    return C?.attributes?.name;
-  });
+      return C?.attributes?.name;
+    })
+    .filter((c) => !!c);
 
   const TABLE_ROWS_DATA = datasetsData?.data
     ?.sort((a, b) => {

--- a/client/src/containers/datasets/categories/index.tsx
+++ b/client/src/containers/datasets/categories/index.tsx
@@ -6,7 +6,7 @@ import { useAtomValue } from "jotai";
 
 import { useGetCategories } from "@/types/generated/category";
 
-import { datasetSearchAtom } from "@/app/store";
+import { datasetSearchAtom, useSyncPublicationState } from "@/app/store";
 
 import { GET_CATEGORIES_OPTIONS } from "@/constants/datasets";
 
@@ -17,12 +17,16 @@ import { Accordion } from "@/components/ui/accordion";
 const DatasetsCategories = () => {
   const [values, setValues] = useState<string[]>();
   const datasetSearch = useAtomValue(datasetSearchAtom);
+  const [publicationState] = useSyncPublicationState();
 
-  const { data: categoriesData } = useGetCategories(GET_CATEGORIES_OPTIONS(datasetSearch), {
-    query: {
-      keepPreviousData: true,
+  const { data: categoriesData } = useGetCategories(
+    GET_CATEGORIES_OPTIONS(datasetSearch, publicationState),
+    {
+      query: {
+        keepPreviousData: true,
+      },
     },
-  });
+  );
 
   const VALUE = useMemo(() => {
     if (!values) return categoriesData?.data?.map((c) => `${c?.id}`);

--- a/client/src/containers/datasets/index.tsx
+++ b/client/src/containers/datasets/index.tsx
@@ -4,7 +4,7 @@ import { useAtomValue } from "jotai";
 
 import { useGetDatasets } from "@/types/generated/dataset";
 
-import { datasetSearchAtom } from "@/app/store";
+import { datasetSearchAtom, useSyncPublicationState } from "@/app/store";
 
 import { GET_DATASETS_OPTIONS } from "@/constants/datasets";
 
@@ -16,12 +16,16 @@ type DatasetsProps = {
 
 const Datasets = ({ categoryId }: DatasetsProps) => {
   const datasetSearch = useAtomValue(datasetSearchAtom);
+  const [publicationState] = useSyncPublicationState();
 
-  const { data: datasetsData } = useGetDatasets(GET_DATASETS_OPTIONS(datasetSearch, categoryId), {
-    query: {
-      keepPreviousData: true,
+  const { data: datasetsData } = useGetDatasets(
+    GET_DATASETS_OPTIONS(datasetSearch, categoryId, publicationState),
+    {
+      query: {
+        keepPreviousData: true,
+      },
     },
-  });
+  );
 
   return (
     <div className="space-y-2.5">

--- a/client/src/containers/map/layer-manager/index.tsx
+++ b/client/src/containers/map/layer-manager/index.tsx
@@ -25,7 +25,10 @@ const LayerManager = () => {
     if (!layers?.length && !layersSettings) return;
 
     if (!layers?.length && layersSettings) {
-      setLayersSettings(null);
+      setTimeout(() => {
+        setLayersSettings(null);
+      }, 0);
+
       return;
     }
 
@@ -34,11 +37,13 @@ const LayerManager = () => {
     lSettingsKeys.forEach((key) => {
       if (layers.includes(Number(key))) return;
 
-      setLayersSettings((prev) => {
-        const current = { ...prev };
-        delete current[key];
-        return current;
-      });
+      setTimeout(() => {
+        setLayersSettings((prev) => {
+          const current = { ...prev };
+          delete current[key];
+          return current;
+        });
+      }, 0);
     });
   }, [layers, layersSettings, setLayersSettings]);
 

--- a/client/src/containers/map/layer-manager/item.tsx
+++ b/client/src/containers/map/layer-manager/item.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback } from "react";
+import { ReactElement, cloneElement, useCallback } from "react";
 
+import { Layer } from "deck.gl/typed";
 import { useAtomValue, useSetAtom } from "jotai";
 
 import { parseConfig } from "@/lib/json-converter";
@@ -117,14 +118,25 @@ const LayerManagerItem = ({ id, beforeId, settings }: LayerManagerItemProps) => 
 
   if (type === "deckgl") {
     const { config, params_config } = data.data.attributes;
-    const c = parseConfig({
-      // TODO: type
+    const c = parseConfig<Layer>({
       config,
       params_config,
       settings,
     });
 
     return <DeckLayer id={`${id}-layer`} beforeId={beforeId} config={c} />;
+  }
+
+  if (type === "component") {
+    const { config, params_config } = data.data.attributes;
+    const c = parseConfig<ReactElement>({
+      config,
+      params_config,
+      settings,
+    });
+
+    if (!c) return null;
+    return cloneElement(c, { id: `${id}-layer`, beforeId });
   }
 };
 

--- a/client/src/containers/map/legend/custom/tree-cover-loss.tsx
+++ b/client/src/containers/map/legend/custom/tree-cover-loss.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from "react";
+
+import { ParamsConfig } from "@/types/layers";
+
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from "@/components/ui/select";
+
+export interface LegendTreeCoverLossProps {
+  description: string;
+  startYear: number;
+  endYear: number;
+  paramsConfig: ParamsConfig;
+  onChangeSettings: (settings: Record<string, unknown>) => unknown;
+}
+
+const LegendTreeCoverLoss: React.FC<LegendTreeCoverLossProps> = ({
+  description,
+  startYear: startYearValue,
+  endYear: endYearValue,
+  paramsConfig,
+  onChangeSettings,
+}) => {
+  const startYear = useMemo(
+    () => paramsConfig.find(({ key }) => key === "startYear")?.default as number,
+    [paramsConfig],
+  );
+
+  const endYear = useMemo(
+    () => paramsConfig.find(({ key }) => key === "endYear")?.default as number,
+    [paramsConfig],
+  );
+
+  const options = useMemo(
+    () =>
+      startYear && endYear
+        ? Array.from({
+            length: endYear - startYear + 1,
+          }).map((_, index) => ({
+            label: startYear + index,
+            value: startYear + index,
+          }))
+        : [],
+    [startYear, endYear],
+  );
+
+  return (
+    <div className="space-y-2.5">
+      <p>{description}</p>
+
+      <div className="flex items-center gap-x-2">
+        <label htmlFor="tree-cover-loss-from">From</label>
+        <Select
+          value={`${startYearValue}`}
+          onValueChange={(value) => onChangeSettings({ startYear: +value })}
+        >
+          <SelectTrigger id="tree-cover-loss-from" className="h-6 w-auto">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map(({ label, value }) => (
+              <SelectItem
+                key={value}
+                value={`${value}`}
+                disabled={value > endYearValue}
+                className="w-full"
+              >
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <label htmlFor="tree-cover-loss-to">to</label>
+        <Select
+          value={`${endYearValue}`}
+          onValueChange={(value) => onChangeSettings({ endYear: +value })}
+        >
+          <SelectTrigger id="tree-cover-loss-to" className="h-6 w-auto">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map(({ label, value }) => (
+              <SelectItem
+                key={value}
+                value={`${value}`}
+                disabled={value < startYearValue}
+                className="w-full"
+              >
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+};
+
+export default LegendTreeCoverLoss;

--- a/client/src/lib/json-converter/index.ts
+++ b/client/src/lib/json-converter/index.ts
@@ -7,6 +7,9 @@ import FUNCTIONS from "@/lib/utils";
 
 import { ParamsConfig } from "@/types/layers";
 
+import LegendTreeCoverLoss from "@/containers/map/legend/custom/tree-cover-loss";
+
+import DecodeLayer from "@/components/map/layers/decode-layer";
 import {
   LegendTypeBasic,
   LegendTypeChoropleth,
@@ -20,6 +23,7 @@ export const JSON_CONFIGURATION = new JSONConfiguration({
     {},
     require("@deck.gl/layers"),
     require("@deck.gl/aggregation-layers"),
+    { DecodeLayer },
   ),
   functions: FUNCTIONS,
   enumerations: {},
@@ -27,6 +31,7 @@ export const JSON_CONFIGURATION = new JSONConfiguration({
     LegendTypeBasic,
     LegendTypeChoropleth,
     LegendTypeGradient,
+    LegendTreeCoverLoss,
   },
 });
 

--- a/client/src/lib/json-converter/index.ts
+++ b/client/src/lib/json-converter/index.ts
@@ -10,6 +10,7 @@ import { ParamsConfig } from "@/types/layers";
 import LegendTreeCoverLoss from "@/containers/map/legend/custom/tree-cover-loss";
 
 import DecodeLayer from "@/components/map/layers/decode-layer";
+import DecodeLayerComponent from "@/components/map/layers/decode-layer/component";
 import {
   LegendTypeBasic,
   LegendTypeChoropleth,
@@ -28,6 +29,7 @@ export const JSON_CONFIGURATION = new JSONConfiguration({
   functions: FUNCTIONS,
   enumerations: {},
   reactComponents: {
+    DecodeLayerComponent,
     LegendTypeBasic,
     LegendTypeChoropleth,
     LegendTypeGradient,

--- a/client/src/lib/json-converter/index.ts
+++ b/client/src/lib/json-converter/index.ts
@@ -11,6 +11,7 @@ import LegendTreeCoverLoss from "@/containers/map/legend/custom/tree-cover-loss"
 
 import DecodeLayer from "@/components/map/layers/decode-layer";
 import DecodeLayerComponent from "@/components/map/layers/decode-layer/component";
+import RingLayerComponent from "@/components/map/layers/ring-layer/component";
 import {
   LegendTypeBasic,
   LegendTypeChoropleth,
@@ -30,6 +31,7 @@ export const JSON_CONFIGURATION = new JSONConfiguration({
   enumerations: {},
   reactComponents: {
     DecodeLayerComponent,
+    RingLayerComponent,
     LegendTypeBasic,
     LegendTypeChoropleth,
     LegendTypeGradient,

--- a/client/src/types/generated/strapi.schemas.ts
+++ b/client/src/types/generated/strapi.schemas.ts
@@ -1941,6 +1941,7 @@ export const LayerType = {
   mapbox: "mapbox",
   deckgl: "deckgl",
   countries: "countries",
+  component: "component",
 } as const;
 
 export interface Layer {
@@ -2027,6 +2028,7 @@ export const LayerDatasetDataAttributesLayersDataItemAttributesType = {
   mapbox: "mapbox",
   deckgl: "deckgl",
   countries: "countries",
+  component: "component",
 } as const;
 
 export type LayerDatasetDataAttributesLayersDataItemAttributesDatasetDataAttributes = {
@@ -2350,6 +2352,7 @@ export const LayerRequestDataType = {
   mapbox: "mapbox",
   deckgl: "deckgl",
   countries: "countries",
+  component: "component",
 } as const;
 
 export type LayerRequestDataDataset = number | string;
@@ -2756,6 +2759,7 @@ export const DatasetCategoryDataAttributesDatasetsDataItemAttributesLayersDataIt
   mapbox: "mapbox",
   deckgl: "deckgl",
   countries: "countries",
+  component: "component",
 } as const;
 
 export type DatasetCategoryDataAttributesDatasetsDataItemAttributesLayersDataItemAttributes = {
@@ -3388,6 +3392,7 @@ export const CategoryDatasetsDataItemAttributesLayersDataItemAttributesType = {
   mapbox: "mapbox",
   deckgl: "deckgl",
   countries: "countries",
+  component: "component",
 } as const;
 
 export type CategoryDatasetsDataItemAttributesLayersDataItemAttributes = {

--- a/client/src/types/layers.ts
+++ b/client/src/types/layers.ts
@@ -14,7 +14,7 @@ export type ParamsConfigValue = {
   default: unknown;
 };
 
-export type ParamsConfig = Record<string, ParamsConfigValue>[];
+export type ParamsConfig = ParamsConfigValue[];
 
 export type LegendConfig = {
   type: "basic" | "gradient" | "choropleth";

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1499,6 +1499,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@choojs/findup@npm:^0.2.0":
+  version: 0.2.1
+  resolution: "@choojs/findup@npm:0.2.1"
+  dependencies:
+    commander: ^2.15.1
+  bin:
+    findup: bin/findup.js
+  checksum: 9496321caa276f2a560ebae0e7607ba009012e8eff16db68fb405561ec482606edecf1c5ce1956805d77721c2db34c4bd9e2e95a2be2eec1c5ae8bb289ed5fd2
+  languageName: node
+  linkType: hard
+
 "@deck.gl/aggregation-layers@npm:8.9.32":
   version: 8.9.32
   resolution: "@deck.gl/aggregation-layers@npm:8.9.32"
@@ -5034,6 +5045,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn@npm:^7.1.1":
+  version: 7.4.1
+  resolution: "acorn@npm:7.4.1"
+  bin:
+    acorn: bin/acorn
+  checksum: 1860f23c2107c910c6177b7b7be71be350db9e1080d814493fae143ae37605189504152d1ba8743ba3178d0b37269ce1ffc42b101547fdc1827078f82671e407
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.8.0, acorn@npm:^8.9.0":
   version: 8.10.0
   resolution: "acorn@npm:8.10.0"
@@ -5554,6 +5574,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bl@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "bl@npm:2.2.1"
+  dependencies:
+    readable-stream: ^2.3.5
+    safe-buffer: ^5.1.1
+  checksum: 4f5d9b258919646a8d02f1731379e53b6f6309e34596ae02afbc3aeb183910bd2d0b70681f889b7c620ca48f65dc1cd0992ee1266c90d6d7c3be60688d141233
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:1.20.1":
   version: 1.20.1
   resolution: "body-parser@npm:1.20.1"
@@ -5636,6 +5666,13 @@ __metadata:
   version: 1.0.1
   resolution: "buf-compare@npm:1.0.1"
   checksum: e5cc98cd36beac306ed481d4f12e524756175f792d288db5b92d9b947e4893c66e43da302d9ea5fbd4553e734b535dd5b3bb5d07e23ea7b059d136ed7582fcf1
+  languageName: node
+  linkType: hard
+
+"buffer-from@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
   languageName: node
   linkType: hard
 
@@ -5835,6 +5872,7 @@ __metadata:
     eslint-plugin-prettier: 5.0.0
     export-to-csv: 1.2.1
     express: 4.18.2
+    glslify: ^7.1.1
     husky: 8.0.3
     jotai: ^2.5.0
     lodash-es: ^4.17.21
@@ -6067,7 +6105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:2, commander@npm:^2.20.3":
+"commander@npm:2, commander@npm:^2.15.1, commander@npm:^2.20.3":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
@@ -6106,6 +6144,18 @@ __metadata:
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
   checksum: 902a9f5d8967a3e2faf138d5cb784b9979bad2e6db5357c5b21c568df4ebe62bcb15108af1b2253744844eb964fc023fbd9afbbbb6ddd0bcc204c6fb5b7bf3af
+  languageName: node
+  linkType: hard
+
+"concat-stream@npm:^1.5.2":
+  version: 1.6.2
+  resolution: "concat-stream@npm:1.6.2"
+  dependencies:
+    buffer-from: ^1.0.0
+    inherits: ^2.0.3
+    readable-stream: ^2.2.2
+    typedarray: ^0.0.6
+  checksum: 1ef77032cb4459dcd5187bd710d6fc962b067b64ec6a505810de3d2b8cc0605638551b42f8ec91edf6fcd26141b32ef19ad749239b58fae3aba99187adc32285
   languageName: node
   linkType: hard
 
@@ -6169,6 +6219,13 @@ __metadata:
   dependencies:
     browserslist: ^4.22.1
   checksum: 4206d3ff282a9188399e9003301fa4b96844152afcea7b9c9accc653542f40f581f77bf079b8be67f614e305da1f29e868a49ceebb6dbe3f5fb4a28bd2dbf431
+  languageName: node
+  linkType: hard
+
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 9de8597363a8e9b9952491ebe18167e3b36e7707569eed0ebf14f8bba773611376466ae34575bca8cfe3c767890c859c74056084738f09d4e4a6f902b2ad7d99
   languageName: node
   linkType: hard
 
@@ -6694,6 +6751,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"duplexify@npm:^3.4.5":
+  version: 3.7.1
+  resolution: "duplexify@npm:3.7.1"
+  dependencies:
+    end-of-stream: ^1.0.0
+    inherits: ^2.0.1
+    readable-stream: ^2.0.0
+    stream-shift: ^1.0.0
+  checksum: 3c2ed2223d956a5da713dae12ba8295acb61d9acd966ccbba938090d04f4574ca4dca75cca089b5077c2d7e66101f32e6ea9b36a78ca213eff574e7a8b8accf2
+  languageName: node
+  linkType: hard
+
 "earcut@npm:^2.0.6, earcut@npm:^2.2.4":
   version: 2.2.4
   resolution: "earcut@npm:2.2.4"
@@ -6752,7 +6821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0":
+"end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0":
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
@@ -7179,6 +7248,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escodegen@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "escodegen@npm:2.1.0"
+  dependencies:
+    esprima: ^4.0.1
+    estraverse: ^5.2.0
+    esutils: ^2.0.2
+    source-map: ~0.6.1
+  dependenciesMeta:
+    source-map:
+      optional: true
+  bin:
+    escodegen: bin/escodegen.js
+    esgenerate: bin/esgenerate.js
+  checksum: 096696407e161305cd05aebb95134ad176708bc5cb13d0dcc89a5fcbb959b8ed757e7f2591a5f8036f8f4952d4a724de0df14cd419e29212729fa6df5ce16bf6
+  languageName: node
+  linkType: hard
+
 "eslint-config-next@npm:13.5.3":
   version: 13.5.3
   resolution: "eslint-config-next@npm:13.5.3"
@@ -7436,7 +7523,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0":
+"esprima@npm:^4.0.0, esprima@npm:^4.0.1":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -7506,7 +7593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.3.0":
+"events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
@@ -7632,6 +7719,16 @@ __metadata:
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: a50a8309ca65ea5d426382ff09f33586527882cf532931cb08ca786ea3146c0553310bda688710ff61d7668eba9f96b923fe1420cdf56a2c3eaf30fcab87b515
+  languageName: node
+  linkType: hard
+
+"falafel@npm:^2.1.0":
+  version: 2.2.5
+  resolution: "falafel@npm:2.2.5"
+  dependencies:
+    acorn: ^7.1.1
+    isarray: ^2.0.1
+  checksum: bfd46e92bca87670fd2ef31c6123088431271f98f3b2a300a58e9c3e5f4f9944f0058f7daaaaa8cefd68d461a334bd528c952bcec17061522b68b61f7925b382
   languageName: node
   linkType: hard
 
@@ -7872,6 +7969,16 @@ __metadata:
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 13ea8b08f91e669a64e3ba3a20eb79d7ca5379a81f1ff7f4310d54e2320645503cc0c78daedc93dfb6191287295f6479544a649c64d8e41a1c0fb0c221552346
+  languageName: node
+  linkType: hard
+
+"from2@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "from2@npm:2.3.0"
+  dependencies:
+    inherits: ^2.0.1
+    readable-stream: ^2.0.0
+  checksum: 6080eba0793dce32f475141fb3d54cc15f84ee52e420ee22ac3ab0ad639dc95a1875bc6eb9c0e1140e94972a36a89dc5542491b85f1ab8df0c126241e0f1a61b
   languageName: node
   linkType: hard
 
@@ -8212,6 +8319,165 @@ __metadata:
     merge2: ^1.4.1
     slash: ^3.0.0
   checksum: b4be8885e0cfa018fc783792942d53926c35c50b3aefd3fdcfb9d22c627639dc26bd2327a40a0b74b074100ce95bb7187bfeae2f236856aa3de183af7a02aea6
+  languageName: node
+  linkType: hard
+
+"glsl-inject-defines@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "glsl-inject-defines@npm:1.0.3"
+  dependencies:
+    glsl-token-inject-block: ^1.0.0
+    glsl-token-string: ^1.0.1
+    glsl-tokenizer: ^2.0.2
+  checksum: 91d707cc4cdc924ec1ea13bcc332357c41754542e3c3d8d95f2331569c339a9cfab37c343e253fea10e56d5a70f930b9027b62431c5c786e34e7d8f785456836
+  languageName: node
+  linkType: hard
+
+"glsl-resolve@npm:0.0.1":
+  version: 0.0.1
+  resolution: "glsl-resolve@npm:0.0.1"
+  dependencies:
+    resolve: ^0.6.1
+    xtend: ^2.1.2
+  checksum: 8bc83f4c56c06d771761c32042fff8fed60f4bcc320d5fc3ec86cf115eb3c0bb5bacf3ca5f80cb88133399734d02c65788845bca9eb90244e08c41e98ddb0275
+  languageName: node
+  linkType: hard
+
+"glsl-token-assignments@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "glsl-token-assignments@npm:2.0.2"
+  checksum: efd6051cfd0e5dc4749cc05530e79c42b2396685345695d1232ab3904011e65f117110a2ef7e92a06bc687abf6182f4e90b6b51cc4ab20147aafcc57f724ecb5
+  languageName: node
+  linkType: hard
+
+"glsl-token-defines@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "glsl-token-defines@npm:1.0.0"
+  dependencies:
+    glsl-tokenizer: ^2.0.0
+  checksum: 79c3738e4c858c1eb400a7d288a372cf275b6aacee4eed2a89f1c4269a9849d3210bbc770123af408bf0a9d8bf909e558154a27f4c976cee287ea9a4bf9b0047
+  languageName: node
+  linkType: hard
+
+"glsl-token-depth@npm:^1.1.0, glsl-token-depth@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "glsl-token-depth@npm:1.1.2"
+  checksum: 97fff701eef20c2ef4552885f060dbf05b307f59b9f1637ddd73c3d5e7d3cc5b4851123706be9f2590042566132f5175ae86a82576bdcfa1edd4625c58d6843c
+  languageName: node
+  linkType: hard
+
+"glsl-token-descope@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "glsl-token-descope@npm:1.0.2"
+  dependencies:
+    glsl-token-assignments: ^2.0.0
+    glsl-token-depth: ^1.1.0
+    glsl-token-properties: ^1.0.0
+    glsl-token-scope: ^1.1.0
+  checksum: a0d578d5e71178cd5679504a94a60e0811980f46fe6b3cb018bb165530faa75ffcb61b62a1984052223cf2455e36c08f9aa72cf3fdce419aac5d8844ec84cf5a
+  languageName: node
+  linkType: hard
+
+"glsl-token-inject-block@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "glsl-token-inject-block@npm:1.1.0"
+  checksum: a08aca0f0684ee00eb9beb44993ab59d6d6330947d282204fe114c09a34fe9b9719f035eda0ed317a5409e5d4118674955c225034bb28c5d8334bcc3f905d7dc
+  languageName: node
+  linkType: hard
+
+"glsl-token-properties@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "glsl-token-properties@npm:1.0.1"
+  checksum: 9b4d1caf02d52f6407479bcd3e780133d6952ba6ae0d85ccd4f3de9ead061a173da0820b0238a0e721ae75370b645152d468bc24eb6f1fd37b5000c500d97cd4
+  languageName: node
+  linkType: hard
+
+"glsl-token-scope@npm:^1.1.0, glsl-token-scope@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "glsl-token-scope@npm:1.1.2"
+  checksum: d62812c81a399d7bdd001ce4414293e508dbd78d480b1984190c8d3243c14817c34109893a71503a50ef09de28e4b0c0124be1979292aba5df3f0207eace1b70
+  languageName: node
+  linkType: hard
+
+"glsl-token-string@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "glsl-token-string@npm:1.0.1"
+  checksum: 3260c1486b620277396ecb92b13434764eddcd59330ffb7a25d0e5fc2750fbd4330899e2acb5ab36408ea7451f3e103418ca0430b4c6a225a7e5f318b5028fda
+  languageName: node
+  linkType: hard
+
+"glsl-token-whitespace-trim@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "glsl-token-whitespace-trim@npm:1.0.0"
+  checksum: ffb0d09118a18fa807a249414762e93835d303f476feae8bbb80320ec850a5aa24fa2760245b374312310ebb0ef099da9a9190ff5b587be45566d2aee1503777
+  languageName: node
+  linkType: hard
+
+"glsl-tokenizer@npm:^2.0.0, glsl-tokenizer@npm:^2.0.2":
+  version: 2.1.5
+  resolution: "glsl-tokenizer@npm:2.1.5"
+  dependencies:
+    through2: ^0.6.3
+  checksum: daf70e91c66a3143fe0b22be18a0f8cc965d7b81f73a58b14d55d08593bdcc3f996996549bda78b4cc822d7fe8c216aaeaab71f2695d802fb79fc9e89fb507d3
+  languageName: node
+  linkType: hard
+
+"glslify-bundle@npm:^5.0.0":
+  version: 5.1.1
+  resolution: "glslify-bundle@npm:5.1.1"
+  dependencies:
+    glsl-inject-defines: ^1.0.1
+    glsl-token-defines: ^1.0.0
+    glsl-token-depth: ^1.1.1
+    glsl-token-descope: ^1.0.2
+    glsl-token-scope: ^1.1.1
+    glsl-token-string: ^1.0.1
+    glsl-token-whitespace-trim: ^1.0.0
+    glsl-tokenizer: ^2.0.2
+    murmurhash-js: ^1.0.0
+    shallow-copy: 0.0.1
+  checksum: e3a5e438dd0ffbdaa72adad23b4eae80258f3f903b3fde3d7022d2f662df1bbb76ce479c2c030ed4aebeb899965e7e3bb7db83748963e0643bbbded3bacdebff
+  languageName: node
+  linkType: hard
+
+"glslify-deps@npm:^1.2.5":
+  version: 1.3.2
+  resolution: "glslify-deps@npm:1.3.2"
+  dependencies:
+    "@choojs/findup": ^0.2.0
+    events: ^3.2.0
+    glsl-resolve: 0.0.1
+    glsl-tokenizer: ^2.0.0
+    graceful-fs: ^4.1.2
+    inherits: ^2.0.1
+    map-limit: 0.0.1
+    resolve: ^1.0.0
+  checksum: 3eb50a26171f66d02582cfa90a9ac7c964ff970d44cd48025af2015fe465be1632cfc7fcec05f5aa4210571ec936c4a26de0e100d9c4d0c2ab655362290a616c
+  languageName: node
+  linkType: hard
+
+"glslify@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "glslify@npm:7.1.1"
+  dependencies:
+    bl: ^2.2.1
+    concat-stream: ^1.5.2
+    duplexify: ^3.4.5
+    falafel: ^2.1.0
+    from2: ^2.3.0
+    glsl-resolve: 0.0.1
+    glsl-token-whitespace-trim: ^1.0.0
+    glslify-bundle: ^5.0.0
+    glslify-deps: ^1.2.5
+    minimist: ^1.2.5
+    resolve: ^1.1.5
+    stack-trace: 0.0.9
+    static-eval: ^2.0.5
+    through2: ^2.0.1
+    xtend: ^4.0.0
+  bin:
+    glslify: bin.js
+  checksum: 2bb59c0480041ca73dcb6e0c6f56d3f063e546c87901f82582a914864ebf836145289316bddb507874bf9405113a3efb3efbeacc0e888337d7d268ef1823ca7b
   languageName: node
   linkType: hard
 
@@ -8576,7 +8842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:~2.0.1, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -8975,10 +9241,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:^2.0.5":
+"isarray@npm:0.0.1":
+  version: 0.0.1
+  resolution: "isarray@npm:0.0.1"
+  checksum: 49191f1425681df4a18c2f0f93db3adb85573bcdd6a4482539d98eac9e705d8961317b01175627e860516a2fc45f8f9302db26e5a380a97a520e272e2a40a8d4
+  languageName: node
+  linkType: hard
+
+"isarray@npm:^2.0.1, isarray@npm:^2.0.5":
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: bd5bbe4104438c4196ba58a54650116007fa0262eccef13a4c55b2e09a5b36b59f1e75b9fcc49883dd9d4953892e6fc007eef9e9155648ceea036e184b0f930a
+  languageName: node
+  linkType: hard
+
+"isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
   languageName: node
   linkType: hard
 
@@ -9550,6 +9830,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"map-limit@npm:0.0.1":
+  version: 0.0.1
+  resolution: "map-limit@npm:0.0.1"
+  dependencies:
+    once: ~1.3.0
+  checksum: e7ad9a66037d4168f2e3dbd20654cb0503126911e0e43c8fe95ae1a3ea54b72e84f94f8577a13598708a29a096cc6ecf136622ea6a5d393c227f84f6f1445b83
+  languageName: node
+  linkType: hard
+
 "mapbox-gl@npm:2.15.0":
   version: 2.15.0
   resolution: "mapbox-gl@npm:2.15.0"
@@ -10004,7 +10293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
@@ -10603,6 +10892,15 @@ __metadata:
   dependencies:
     wrappy: 1
   checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+  languageName: node
+  linkType: hard
+
+"once@npm:~1.3.0":
+  version: 1.3.3
+  resolution: "once@npm:1.3.3"
+  dependencies:
+    wrappy: 1
+  checksum: 8e832de08b1d73b470e01690c211cb4fcefccab1fd1bd19e706d572d74d3e9b7e38a8bfcdabdd364f9f868757d9e8e5812a59817dc473eaf698ff3bfae2219f2
   languageName: node
   linkType: hard
 
@@ -11220,6 +11518,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process-nextick-args@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
+  languageName: node
+  linkType: hard
+
 "process-warning@npm:^2.0.0":
   version: 2.2.0
   resolution: "process-warning@npm:2.2.0"
@@ -11538,6 +11843,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:>=1.0.33-1 <1.1.0-0":
+  version: 1.0.34
+  resolution: "readable-stream@npm:1.0.34"
+  dependencies:
+    core-util-is: ~1.0.0
+    inherits: ~2.0.1
+    isarray: 0.0.1
+    string_decoder: ~0.10.x
+  checksum: 85042c537e4f067daa1448a7e257a201070bfec3dd2706abdbd8ebc7f3418eb4d3ed4b8e5af63e2544d69f88ab09c28d5da3c0b77dc76185fddd189a59863b60
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^2.0.0, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.5, readable-stream@npm:~2.3.6":
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
+  dependencies:
+    core-util-is: ~1.0.0
+    inherits: ~2.0.3
+    isarray: ~1.0.0
+    process-nextick-args: ~2.0.0
+    safe-buffer: ~5.1.1
+    string_decoder: ~1.1.1
+    util-deprecate: ~1.0.1
+  checksum: 65645467038704f0c8aaf026a72fbb588a9e2ef7a75cd57a01702ee9db1c4a1e4b03aaad36861a6a0926546a74d174149c8c207527963e0c2d3eee2f37678a42
+  languageName: node
+  linkType: hard
+
 "readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
@@ -11743,7 +12075,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.14.2, resolve@npm:^1.17.0, resolve@npm:^1.22.2, resolve@npm:^1.22.4":
+"resolve@npm:^0.6.1":
+  version: 0.6.3
+  resolution: "resolve@npm:0.6.3"
+  checksum: c3b5d34ba79635ffe380eb0e428e0b49259734ad2c86945c6b3238155b0753d8bcf858c6b99966b3fdb536062f6e204675e4542269f065e34210bb3a6f602f9d
+  languageName: node
+  linkType: hard
+
+"resolve@npm:^1.0.0, resolve@npm:^1.1.5, resolve@npm:^1.1.7, resolve@npm:^1.14.2, resolve@npm:^1.17.0, resolve@npm:^1.22.2, resolve@npm:^1.22.4":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -11769,7 +12108,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>":
+"resolve@patch:resolve@^0.6.1#~builtin<compat/resolve>":
+  version: 0.6.3
+  resolution: "resolve@patch:resolve@npm%3A0.6.3#~builtin<compat/resolve>::version=0.6.3&hash=3bafbf"
+  checksum: fbdc248b89f655da8ff1509c000027702455d36e99943307d6e939bbef8b6f2bf67f82aa82ceb968f121febea128dd9b3e544fc6497c105204b1633bee1efad9
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.0.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.5#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#~builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -11886,10 +12232,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.1.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
   languageName: node
   linkType: hard
 
@@ -12049,6 +12402,13 @@ __metadata:
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: be18cbbf70e7d8097c97f713a2e76edf84e87299b40d085c6bf8b65314e994cc15e2e317727342fa6996e38e1f52c59720b53fe621e2eb593a6847bf0356db89
+  languageName: node
+  linkType: hard
+
+"shallow-copy@npm:0.0.1":
+  version: 0.0.1
+  resolution: "shallow-copy@npm:0.0.1"
+  checksum: 2d249a5a57a160b439d84fbf9ed7c0a107a3d656d1bda0b73edf9476c6e6ea9d2afa79829bf33fce6677fae35b15c14e5c28f9902dc4d07a302637a225d00634
   languageName: node
   linkType: hard
 
@@ -12247,7 +12607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.1":
+"source-map@npm:^0.6.1, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
@@ -12300,6 +12660,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stack-trace@npm:0.0.9":
+  version: 0.0.9
+  resolution: "stack-trace@npm:0.0.9"
+  checksum: 5b1ff9708eaeae2518f70ea10027aa608892faedfd95d3c92b0e3b14cf49b013da22421a32b5bbe29ae711436e53fdf966793cf58a4bd0ad20a71859d27a894f
+  languageName: node
+  linkType: hard
+
 "stacktracey@npm:^2.1.7":
   version: 2.1.8
   resolution: "stacktracey@npm:2.1.8"
@@ -12310,10 +12677,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"static-eval@npm:^2.0.5":
+  version: 2.1.1
+  resolution: "static-eval@npm:2.1.1"
+  dependencies:
+    escodegen: ^2.1.0
+  checksum: b59ea64cb4c2948c2c9dd9d156ee53b64b12e787148f8bc1d14a76d039d06b07e6470ce5924881c9a807d05c567b62092017c29d632ea8112a21f5ac268117b1
+  languageName: node
+  linkType: hard
+
 "statuses@npm:2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
   checksum: 18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
+  languageName: node
+  linkType: hard
+
+"stream-shift@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "stream-shift@npm:1.0.1"
+  checksum: 59b82b44b29ec3699b5519a49b3cedcc6db58c72fb40c04e005525dfdcab1c75c4e0c180b923c380f204bed78211b9bad8faecc7b93dece4d004c3f6ec75737b
   languageName: node
   linkType: hard
 
@@ -12409,6 +12792,22 @@ __metadata:
   dependencies:
     safe-buffer: ~5.2.0
   checksum: 8417646695a66e73aefc4420eb3b84cc9ffd89572861fe004e6aeb13c7bc00e2f616247505d2dbbef24247c372f70268f594af7126f43548565c68c117bdeb56
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~0.10.x":
+  version: 0.10.31
+  resolution: "string_decoder@npm:0.10.31"
+  checksum: fe00f8e303647e5db919948ccb5ce0da7dea209ab54702894dd0c664edd98e5d4df4b80d6fabf7b9e92b237359d21136c95bf068b2f7760b772ca974ba970202
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "string_decoder@npm:1.1.1"
+  dependencies:
+    safe-buffer: ~5.1.0
+  checksum: 9ab7e56f9d60a28f2be697419917c50cac19f3e8e6c28ef26ed5f4852289fe0de5d6997d29becf59028556f2c62983790c1d9ba1e2a3cc401768ca12d5183a5b
   languageName: node
   linkType: hard
 
@@ -12714,6 +13113,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"through2@npm:^0.6.3":
+  version: 0.6.5
+  resolution: "through2@npm:0.6.5"
+  dependencies:
+    readable-stream: ">=1.0.33-1 <1.1.0-0"
+    xtend: ">=4.0.0 <4.1.0-0"
+  checksum: dfea228e3134a33219a588448847250897a9994a687807dab52f850fac8b4eb1dc18e3b2c1d3d60dd0d78eb492d2032fdf814ac6576ba5b8d5ba0dade29a3544
+  languageName: node
+  linkType: hard
+
+"through2@npm:^2.0.1":
+  version: 2.0.5
+  resolution: "through2@npm:2.0.5"
+  dependencies:
+    readable-stream: ~2.3.6
+    xtend: ~4.0.1
+  checksum: beb0f338aa2931e5660ec7bf3ad949e6d2e068c31f4737b9525e5201b824ac40cac6a337224856b56bd1ddd866334bbfb92a9f57cd6f66bc3f18d3d86fc0fe50
+  languageName: node
+  linkType: hard
+
 "tilebelt@npm:^1.0.1":
   version: 1.0.1
   resolution: "tilebelt@npm:1.0.1"
@@ -12905,6 +13324,13 @@ __metadata:
     for-each: ^0.3.3
     is-typed-array: ^1.1.9
   checksum: 2228febc93c7feff142b8c96a58d4a0d7623ecde6c7a24b2b98eb3170e99f7c7eff8c114f9b283085cd59dcd2bd43aadf20e25bba4b034a53c5bb292f71f8956
+  languageName: node
+  linkType: hard
+
+"typedarray@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "typedarray@npm:0.0.6"
+  checksum: 33b39f3d0e8463985eeaeeacc3cb2e28bc3dfaf2a5ed219628c0b629d5d7b810b0eb2165f9f607c34871d5daa92ba1dc69f49051cf7d578b4cbd26c340b9d1b1
   languageName: node
   linkType: hard
 
@@ -13178,7 +13604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2":
+"util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
@@ -13394,6 +13820,20 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
+  languageName: node
+  linkType: hard
+
+"xtend@npm:>=4.0.0 <4.1.0-0, xtend@npm:^4.0.0, xtend@npm:~4.0.1":
+  version: 4.0.2
+  resolution: "xtend@npm:4.0.2"
+  checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
+  languageName: node
+  linkType: hard
+
+"xtend@npm:^2.1.2":
+  version: 2.2.0
+  resolution: "xtend@npm:2.2.0"
+  checksum: 9fcd1ddabefdb3c68a698b08177525ad14a6df3423b13bad9a53900d19374e476a43c219b0756d39675776b2326a35fe477c547cfb8a05ae9fea4ba2235bebe2
   languageName: node
   linkType: hard
 

--- a/cms/src/api/layer/content-types/layer/schema.json
+++ b/cms/src/api/layer/content-types/layer/schema.json
@@ -20,7 +20,8 @@
       "enum": [
         "mapbox",
         "deckgl",
-        "countries"
+        "countries",
+        "component"
       ],
       "required": true,
       "default": "mapbox"

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -836,7 +836,9 @@ export interface ApiLayerLayer extends Schema.CollectionType {
   };
   attributes: {
     name: Attribute.String;
-    type: Attribute.Enumeration<['mapbox', 'deckgl', 'countries']> &
+    type: Attribute.Enumeration<
+      ['mapbox', 'deckgl', 'countries', 'component']
+    > &
       Attribute.Required &
       Attribute.DefaultTo<'mapbox'>;
     config: Attribute.JSON & Attribute.Required;


### PR DESCRIPTION
This PR adds:
- `DecodedLayer` class
- `LegendTreeCoverLoss` to be used in JSONConverter

#### config
```
{
  "@@type": "DecodeLayer",
  "source": {
    "type": "raster",
    "tiles": [
      "https://tiles.globalforestwatch.org/umd_tree_cover_loss/v1.10/tcd_30/{z}/{x}/{y}.png"
    ],
    "maxzoom": 12,
    "minzoom": 2
  },
  "opacity": "@@#params.opacity",
  "visibility": "@@#params.visibility",
  "decodeParams": {
    "endYear": "@@#params.endYear",
    "startYear": "@@#params.startYear"
  },
  "decodeFunction": "// values for creating power scale, domain (input), and range (output)\nfloat domainMin = 0.;\nfloat domainMax = 255.;\nfloat rangeMin = 0.;\nfloat rangeMax = 255.;\nfloat exponent = zoom < 13. ? 0.3 + (zoom - 3.) / 20. : 1.;\nfloat intensity = color.r * 255.;\n// get the min, max, and current values on the power scale\nfloat minPow = pow(domainMin, exponent - domainMin);\nfloat maxPow = pow(domainMax, exponent);\nfloat currentPow = pow(intensity, exponent);\n// get intensity value mapped to range\nfloat scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;\n// a value between 0 and 255\ncolor.a *= zoom < 13. ? scaleIntensity / 255. : color.g;\nfloat year = 2000.0 + (color.b * 255.);\n// map to years\nif (year >= startYear && year <= endYear && year >= 2001.) {\n  color.r = 220. / 255.;\n  color.g = (72. - zoom + 102. - 3. * scaleIntensity / zoom) / 255.;\n  color.b = (33. - zoom + 153. - intensity / zoom) / 255.;\n} else {\n  color.a = 0.;\n}"
}
```

#### params_config
```
[
  {
    "key": "opacity",
    "default": 1
  },
  {
    "key": "visibility",
    "default": true
  },
  {
    "key": "startYear",
    "default": 2001
  },
  {
    "key": "endYear",
    "default": 2022
  }
]
```

#### legend_config
```
{
  "@@type": "LegendTreeCoverLoss",
  "endYear": "@@#params.endYear",
  "startYear": "@@#params.startYear",
  "description": "Displaying Tree cover loss with >30% canopy density."
}
```