### PR TITLE
Mapbox style from ccsa

### DIFF
--- a/client/src/components/map/index.tsx
+++ b/client/src/components/map/index.tsx
@@ -16,7 +16,7 @@ import env from "@/env.mjs";
 
 import { cn } from "@/lib/classnames";
 
-import { DEFAULT_VIEW_STATE } from "../../constants/map";
+import { DEFAULT_VIEW_STATE, MAPBOX_STYLE } from "../../constants/map";
 
 import type { CustomMapProps } from "./types";
 
@@ -146,7 +146,7 @@ export const Map: FC<CustomMapProps> = ({
         mapboxAccessToken={env.NEXT_PUBLIC_MAPBOX_API_TOKEN}
         onMove={handleMapMove}
         onLoad={handleMapLoad}
-        mapStyle="mapbox://styles/layer-manager/clj8fgofm000t01pjcu21agsd"
+        mapStyle={MAPBOX_STYLE}
         {...mapboxProps}
         {...localViewState}
       >

--- a/client/src/constants/map.ts
+++ b/client/src/constants/map.ts
@@ -6,6 +6,8 @@ export const DEFAULT_VIEW_STATE: Partial<ViewState> = {
   longitude: 0,
 };
 
+export const MAPBOX_STYLE = "mapbox://styles/caribbeanaccelerator/clp6tnp8s00fr01qx2saz77ph";
+
 export const DEFAULT_BBOX: [number, number, number, number] = [
   -118.3665 * 1.1,
   1.1768 * 1.1,


### PR DESCRIPTION
This PR adds:
- Mapbox styles from CCSA account
- We must change the `NEXT_PUBLIC_MAPBOX_API_TOKEN` in Production and Staging