### PR TITLE
Add resouce to Dataset value_type

### DIFF
--- a/cms/src/api/dataset/content-types/dataset/schema.json
+++ b/cms/src/api/dataset/content-types/dataset/schema.json
@@ -45,7 +45,8 @@
       "enum": [
         "text",
         "number",
-        "boolean"
+        "boolean",
+        "resource"
       ],
       "required": true
     }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -773,7 +773,9 @@ export interface ApiDatasetDataset extends Schema.CollectionType {
       'api::layer.layer'
     >;
     unit: Attribute.String;
-    value_type: Attribute.Enumeration<['text', 'number', 'boolean']> &
+    value_type: Attribute.Enumeration<
+      ['text', 'number', 'boolean', 'resource']
+    > &
       Attribute.Required;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;


### PR DESCRIPTION
This PR adds the value 'resource' to the Dataset property 'value_type'