### PR TITLE
Add Collection type for change approval system

### DIFF
--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -10,7 +10,9 @@
       "properties": {
         "fields": [
           "name",
-          "datasets"
+          "datasets",
+          "new_dataset_suggestions",
+          "dataset_edit_suggestions"
         ]
       },
       "conditions": []
@@ -36,7 +38,9 @@
       "properties": {
         "fields": [
           "name",
-          "datasets"
+          "datasets",
+          "new_dataset_suggestions",
+          "dataset_edit_suggestions"
         ]
       },
       "conditions": []
@@ -48,7 +52,68 @@
       "properties": {
         "fields": [
           "name",
-          "datasets"
+          "datasets",
+          "new_dataset_suggestions",
+          "dataset_edit_suggestions"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::collaborator-edit-suggestion.collaborator-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "link",
+          "type",
+          "collaborator",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::collaborator-edit-suggestion.collaborator-edit-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::collaborator-edit-suggestion.collaborator-edit-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::collaborator-edit-suggestion.collaborator-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "link",
+          "type",
+          "collaborator",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::collaborator-edit-suggestion.collaborator-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "link",
+          "type",
+          "collaborator",
+          "review_status"
         ]
       },
       "conditions": []
@@ -61,7 +126,8 @@
         "fields": [
           "name",
           "link",
-          "type"
+          "type",
+          "collaborator_edit_suggestions"
         ]
       },
       "conditions": []
@@ -88,7 +154,8 @@
         "fields": [
           "name",
           "link",
-          "type"
+          "type",
+          "collaborator_edit_suggestions"
         ]
       },
       "conditions": []
@@ -101,7 +168,8 @@
         "fields": [
           "name",
           "link",
-          "type"
+          "type",
+          "collaborator_edit_suggestions"
         ]
       },
       "conditions": []
@@ -168,15 +236,18 @@
     {
       "action": "plugin::content-manager.explorer.create",
       "actionParameters": {},
-      "subject": "api::dataset-value.dataset-value",
+      "subject": "api::dataset-edit-suggestion.dataset-edit-suggestion",
       "properties": {
         "fields": [
-          "dataset",
-          "country",
-          "value_text",
-          "value_number",
-          "value_boolean",
-          "resources"
+          "name",
+          "datum",
+          "category",
+          "description",
+          "layers",
+          "unit",
+          "value_type",
+          "review_status",
+          "dataset"
         ]
       },
       "conditions": []
@@ -184,22 +255,32 @@
     {
       "action": "plugin::content-manager.explorer.delete",
       "actionParameters": {},
-      "subject": "api::dataset-value.dataset-value",
+      "subject": "api::dataset-edit-suggestion.dataset-edit-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::dataset-edit-suggestion.dataset-edit-suggestion",
       "properties": {},
       "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
       "actionParameters": {},
-      "subject": "api::dataset-value.dataset-value",
+      "subject": "api::dataset-edit-suggestion.dataset-edit-suggestion",
       "properties": {
         "fields": [
-          "dataset",
-          "country",
-          "value_text",
-          "value_number",
-          "value_boolean",
-          "resources"
+          "name",
+          "datum",
+          "category",
+          "description",
+          "layers",
+          "unit",
+          "value_type",
+          "review_status",
+          "dataset"
         ]
       },
       "conditions": []
@@ -207,15 +288,18 @@
     {
       "action": "plugin::content-manager.explorer.update",
       "actionParameters": {},
-      "subject": "api::dataset-value.dataset-value",
+      "subject": "api::dataset-edit-suggestion.dataset-edit-suggestion",
       "properties": {
         "fields": [
-          "dataset",
-          "country",
-          "value_text",
-          "value_number",
-          "value_boolean",
-          "resources"
+          "name",
+          "datum",
+          "category",
+          "description",
+          "layers",
+          "unit",
+          "value_type",
+          "review_status",
+          "dataset"
         ]
       },
       "conditions": []
@@ -287,7 +371,8 @@
           "description",
           "layers",
           "unit",
-          "value_type"
+          "value_type",
+          "dataset_edit_suggestions"
         ]
       },
       "conditions": []
@@ -318,7 +403,8 @@
           "description",
           "layers",
           "unit",
-          "value_type"
+          "value_type",
+          "dataset_edit_suggestions"
         ]
       },
       "conditions": []
@@ -335,7 +421,8 @@
           "description",
           "layers",
           "unit",
-          "value_type"
+          "value_type",
+          "dataset_edit_suggestions"
         ]
       },
       "conditions": []
@@ -402,7 +489,9 @@
           "params_config",
           "legend_config",
           "interaction_config",
-          "dataset"
+          "dataset",
+          "new_dataset_suggestion",
+          "dataset_edit_suggestion"
         ]
       },
       "conditions": []
@@ -433,7 +522,9 @@
           "params_config",
           "legend_config",
           "interaction_config",
-          "dataset"
+          "dataset",
+          "new_dataset_suggestion",
+          "dataset_edit_suggestion"
         ]
       },
       "conditions": []
@@ -450,7 +541,278 @@
           "params_config",
           "legend_config",
           "interaction_config",
-          "dataset"
+          "dataset",
+          "new_dataset_suggestion",
+          "dataset_edit_suggestion"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::new-collaborator-suggestion.new-collaborator-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "link",
+          "type",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::new-collaborator-suggestion.new-collaborator-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::new-collaborator-suggestion.new-collaborator-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::new-collaborator-suggestion.new-collaborator-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "link",
+          "type",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::new-collaborator-suggestion.new-collaborator-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "link",
+          "type",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::new-dataset-suggestion.new-dataset-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "datum",
+          "category",
+          "description",
+          "layers",
+          "unit",
+          "value_type",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::new-dataset-suggestion.new-dataset-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::new-dataset-suggestion.new-dataset-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::new-dataset-suggestion.new-dataset-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "datum",
+          "category",
+          "description",
+          "layers",
+          "unit",
+          "value_type",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::new-dataset-suggestion.new-dataset-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "datum",
+          "category",
+          "description",
+          "layers",
+          "unit",
+          "value_type",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::new-project-suggestion.new-project-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "status",
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::new-project-suggestion.new-project-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::new-project-suggestion.new-project-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::new-project-suggestion.new-project-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "status",
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::new-project-suggestion.new-project-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "status",
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::new-tool-suggestion.new-tool-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "description",
+          "link",
+          "other_tools_category",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::new-tool-suggestion.new-tool-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::new-tool-suggestion.new-tool-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::new-tool-suggestion.new-tool-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "description",
+          "link",
+          "other_tools_category",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::new-tool-suggestion.new-tool-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "description",
+          "link",
+          "other_tools_category",
+          "review_status"
         ]
       },
       "conditions": []
@@ -464,7 +826,8 @@
           "name",
           "description",
           "link",
-          "other_tools_category"
+          "other_tools_category",
+          "tool_edit_suggestions"
         ]
       },
       "conditions": []
@@ -492,7 +855,8 @@
           "name",
           "description",
           "link",
-          "other_tools_category"
+          "other_tools_category",
+          "tool_edit_suggestions"
         ]
       },
       "conditions": []
@@ -506,7 +870,8 @@
           "name",
           "description",
           "link",
-          "other_tools_category"
+          "other_tools_category",
+          "tool_edit_suggestions"
         ]
       },
       "conditions": []
@@ -566,7 +931,9 @@
         "fields": [
           "name",
           "projects",
-          "description"
+          "description",
+          "new_project_suggestions",
+          "project_edit_suggestions"
         ]
       },
       "conditions": []
@@ -593,7 +960,9 @@
         "fields": [
           "name",
           "projects",
-          "description"
+          "description",
+          "new_project_suggestions",
+          "project_edit_suggestions"
         ]
       },
       "conditions": []
@@ -606,7 +975,98 @@
         "fields": [
           "name",
           "projects",
-          "description"
+          "description",
+          "new_project_suggestions",
+          "project_edit_suggestions"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::project-edit-suggestion.project-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "status",
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "review_status",
+          "project"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::project-edit-suggestion.project-edit-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::project-edit-suggestion.project-edit-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::project-edit-suggestion.project-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "status",
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "review_status",
+          "project"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::project-edit-suggestion.project-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "status",
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "review_status",
+          "project"
         ]
       },
       "conditions": []
@@ -625,7 +1085,12 @@
           "amount",
           "sdgs",
           "status",
-          "funding"
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "project_edit_suggestions"
         ]
       },
       "conditions": []
@@ -658,7 +1123,12 @@
           "amount",
           "sdgs",
           "status",
-          "funding"
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "project_edit_suggestions"
         ]
       },
       "conditions": []
@@ -677,60 +1147,12 @@
           "amount",
           "sdgs",
           "status",
-          "funding"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
-      "subject": "api::resource.resource",
-      "properties": {
-        "fields": [
-          "link_title",
-          "link_url",
-          "description"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.delete",
-      "actionParameters": {},
-      "subject": "api::resource.resource",
-      "properties": {},
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.publish",
-      "actionParameters": {},
-      "subject": "api::resource.resource",
-      "properties": {},
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::resource.resource",
-      "properties": {
-        "fields": [
-          "link_title",
-          "link_url",
-          "description"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
-      "subject": "api::resource.resource",
-      "properties": {
-        "fields": [
-          "link_title",
-          "link_url",
-          "description"
+          "funding",
+          "source_country",
+          "organization_type",
+          "objective",
+          "info",
+          "project_edit_suggestions"
         ]
       },
       "conditions": []
@@ -795,7 +1217,9 @@
       "properties": {
         "fields": [
           "name",
-          "projects"
+          "projects",
+          "new_project_suggestions",
+          "project_edit_suggestions"
         ]
       },
       "conditions": []
@@ -821,7 +1245,9 @@
       "properties": {
         "fields": [
           "name",
-          "projects"
+          "projects",
+          "new_project_suggestions",
+          "project_edit_suggestions"
         ]
       },
       "conditions": []
@@ -833,7 +1259,71 @@
       "properties": {
         "fields": [
           "name",
-          "projects"
+          "projects",
+          "new_project_suggestions",
+          "project_edit_suggestions"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::tool-edit-suggestion.tool-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "description",
+          "link",
+          "other_tools_category",
+          "other_tool",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::tool-edit-suggestion.tool-edit-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::tool-edit-suggestion.tool-edit-suggestion",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::tool-edit-suggestion.tool-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "description",
+          "link",
+          "other_tools_category",
+          "other_tool",
+          "review_status"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::tool-edit-suggestion.tool-edit-suggestion",
+      "properties": {
+        "fields": [
+          "name",
+          "description",
+          "link",
+          "other_tools_category",
+          "other_tool",
+          "review_status"
         ]
       },
       "conditions": []

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##category.category.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##category.category.json
@@ -49,6 +49,36 @@
           "sortable": false
         }
       },
+      "new_dataset_suggestions": {
+        "edit": {
+          "label": "new_dataset_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "new_dataset_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "dataset_edit_suggestions": {
+        "edit": {
+          "label": "dataset_edit_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "dataset_edit_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -109,6 +139,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "name",
+        "createdAt",
+        "datasets"
+      ],
       "edit": [
         [
           {
@@ -120,14 +156,18 @@
           {
             "name": "datasets",
             "size": 4
+          },
+          {
+            "name": "new_dataset_suggestions",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "dataset_edit_suggestions",
+            "size": 6
           }
         ]
-      ],
-      "list": [
-        "id",
-        "name",
-        "createdAt",
-        "datasets"
       ]
     }
   },

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##collaborator-edit-suggestion.collaborator-edit-suggestion.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##collaborator-edit-suggestion.collaborator-edit-suggestion.json
@@ -1,12 +1,12 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::layer.layer",
+  "key": "plugin_content_manager_configuration_content_types::api::collaborator-edit-suggestion.collaborator-edit-suggestion",
   "value": {
-    "uid": "api::layer.layer",
+    "uid": "api::collaborator-edit-suggestion.collaborator-edit-suggestion",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
-      "pageSize": 20,
+      "pageSize": 10,
       "mainField": "name",
       "defaultSortBy": "name",
       "defaultSortOrder": "ASC"
@@ -34,6 +34,20 @@
           "sortable": true
         }
       },
+      "link": {
+        "edit": {
+          "label": "link",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "link",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "type": {
         "edit": {
           "label": "type",
@@ -48,65 +62,9 @@
           "sortable": true
         }
       },
-      "config": {
+      "collaborator": {
         "edit": {
-          "label": "config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "params_config": {
-        "edit": {
-          "label": "params_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "params_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "legend_config": {
-        "edit": {
-          "label": "legend_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "legend_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "interaction_config": {
-        "edit": {
-          "label": "interaction_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "interaction_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "dataset": {
-        "edit": {
-          "label": "dataset",
+          "label": "collaborator",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -114,37 +72,21 @@
           "mainField": "name"
         },
         "list": {
-          "label": "dataset",
+          "label": "collaborator",
           "searchable": true,
           "sortable": true
         }
       },
-      "new_dataset_suggestion": {
+      "review_status": {
         "edit": {
-          "label": "new_dataset_suggestion",
+          "label": "review_status",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "name"
+          "editable": true
         },
         "list": {
-          "label": "new_dataset_suggestion",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "dataset_edit_suggestion": {
-        "edit": {
-          "label": "dataset_edit_suggestion",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "dataset_edit_suggestion",
+          "label": "review_status",
           "searchable": true,
           "sortable": true
         }
@@ -212,13 +154,17 @@
       "list": [
         "id",
         "name",
-        "type",
-        "updatedAt"
+        "link",
+        "type"
       ],
       "edit": [
         [
           {
             "name": "name",
+            "size": 6
+          },
+          {
+            "name": "link",
             "size": 6
           }
         ],
@@ -226,45 +172,15 @@
           {
             "name": "type",
             "size": 6
-          }
-        ],
-        [
-          {
-            "name": "dataset",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "params_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "legend_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "interaction_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "new_dataset_suggestion",
-            "size": 6
           },
           {
-            "name": "dataset_edit_suggestion",
+            "name": "collaborator",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "review_status",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##collaborator.collaborator.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##collaborator.collaborator.json
@@ -62,6 +62,21 @@
           "sortable": true
         }
       },
+      "collaborator_edit_suggestions": {
+        "edit": {
+          "label": "collaborator_edit_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "collaborator_edit_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -142,6 +157,10 @@
         [
           {
             "name": "type",
+            "size": 6
+          },
+          {
+            "name": "collaborator_edit_suggestions",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##dataset-edit-suggestion.dataset-edit-suggestion.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##dataset-edit-suggestion.dataset-edit-suggestion.json
@@ -1,12 +1,12 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::layer.layer",
+  "key": "plugin_content_manager_configuration_content_types::api::dataset-edit-suggestion.dataset-edit-suggestion",
   "value": {
-    "uid": "api::layer.layer",
+    "uid": "api::dataset-edit-suggestion.dataset-edit-suggestion",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
-      "pageSize": 20,
+      "pageSize": 10,
       "mainField": "name",
       "defaultSortBy": "name",
       "defaultSortOrder": "ASC"
@@ -34,74 +34,104 @@
           "sortable": true
         }
       },
-      "type": {
+      "datum": {
         "edit": {
-          "label": "type",
+          "label": "datum",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "type",
+          "label": "datum",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "category": {
+        "edit": {
+          "label": "category",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "category",
           "searchable": true,
           "sortable": true
         }
       },
-      "config": {
+      "description": {
         "edit": {
-          "label": "config",
+          "label": "description",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "config",
+          "label": "description",
           "searchable": false,
           "sortable": false
         }
       },
-      "params_config": {
+      "layers": {
         "edit": {
-          "label": "params_config",
+          "label": "layers",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "name"
         },
         "list": {
-          "label": "params_config",
+          "label": "layers",
           "searchable": false,
           "sortable": false
         }
       },
-      "legend_config": {
+      "unit": {
         "edit": {
-          "label": "legend_config",
+          "label": "unit",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "legend_config",
-          "searchable": false,
-          "sortable": false
+          "label": "unit",
+          "searchable": true,
+          "sortable": true
         }
       },
-      "interaction_config": {
+      "value_type": {
         "edit": {
-          "label": "interaction_config",
+          "label": "value_type",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "interaction_config",
-          "searchable": false,
-          "sortable": false
+          "label": "value_type",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "review_status": {
+        "edit": {
+          "label": "review_status",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "review_status",
+          "searchable": true,
+          "sortable": true
         }
       },
       "dataset": {
@@ -115,36 +145,6 @@
         },
         "list": {
           "label": "dataset",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "new_dataset_suggestion": {
-        "edit": {
-          "label": "new_dataset_suggestion",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "new_dataset_suggestion",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "dataset_edit_suggestion": {
-        "edit": {
-          "label": "dataset_edit_suggestion",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "dataset_edit_suggestion",
           "searchable": true,
           "sortable": true
         }
@@ -212,8 +212,8 @@
       "list": [
         "id",
         "name",
-        "type",
-        "updatedAt"
+        "category",
+        "layers"
       ],
       "edit": [
         [
@@ -224,47 +224,45 @@
         ],
         [
           {
-            "name": "type",
+            "name": "datum",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "category",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "description",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "layers",
+            "size": 6
+          },
+          {
+            "name": "unit",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "value_type",
+            "size": 6
+          },
+          {
+            "name": "review_status",
             "size": 6
           }
         ],
         [
           {
             "name": "dataset",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "params_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "legend_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "interaction_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "new_dataset_suggestion",
-            "size": 6
-          },
-          {
-            "name": "dataset_edit_suggestion",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##dataset.dataset.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##dataset.dataset.json
@@ -120,6 +120,21 @@
           "sortable": true
         }
       },
+      "dataset_edit_suggestions": {
+        "edit": {
+          "label": "dataset_edit_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "dataset_edit_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -224,6 +239,12 @@
           },
           {
             "name": "value_type",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "dataset_edit_suggestions",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##new-collaborator-suggestion.new-collaborator-suggestion.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##new-collaborator-suggestion.new-collaborator-suggestion.json
@@ -1,12 +1,12 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::layer.layer",
+  "key": "plugin_content_manager_configuration_content_types::api::new-collaborator-suggestion.new-collaborator-suggestion",
   "value": {
-    "uid": "api::layer.layer",
+    "uid": "api::new-collaborator-suggestion.new-collaborator-suggestion",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
-      "pageSize": 20,
+      "pageSize": 10,
       "mainField": "name",
       "defaultSortBy": "name",
       "defaultSortOrder": "ASC"
@@ -34,6 +34,20 @@
           "sortable": true
         }
       },
+      "link": {
+        "edit": {
+          "label": "link",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "link",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "type": {
         "edit": {
           "label": "type",
@@ -48,103 +62,16 @@
           "sortable": true
         }
       },
-      "config": {
+      "review_status": {
         "edit": {
-          "label": "config",
+          "label": "review_status",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "params_config": {
-        "edit": {
-          "label": "params_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "params_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "legend_config": {
-        "edit": {
-          "label": "legend_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "legend_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "interaction_config": {
-        "edit": {
-          "label": "interaction_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "interaction_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "dataset": {
-        "edit": {
-          "label": "dataset",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "dataset",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "new_dataset_suggestion": {
-        "edit": {
-          "label": "new_dataset_suggestion",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "new_dataset_suggestion",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "dataset_edit_suggestion": {
-        "edit": {
-          "label": "dataset_edit_suggestion",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "dataset_edit_suggestion",
+          "label": "review_status",
           "searchable": true,
           "sortable": true
         }
@@ -212,13 +139,17 @@
       "list": [
         "id",
         "name",
-        "type",
-        "updatedAt"
+        "link",
+        "type"
       ],
       "edit": [
         [
           {
             "name": "name",
+            "size": 6
+          },
+          {
+            "name": "link",
             "size": 6
           }
         ],
@@ -226,45 +157,9 @@
           {
             "name": "type",
             "size": 6
-          }
-        ],
-        [
-          {
-            "name": "dataset",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "params_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "legend_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "interaction_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "new_dataset_suggestion",
-            "size": 6
           },
           {
-            "name": "dataset_edit_suggestion",
+            "name": "review_status",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##new-dataset-suggestion.new-dataset-suggestion.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##new-dataset-suggestion.new-dataset-suggestion.json
@@ -1,12 +1,12 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::layer.layer",
+  "key": "plugin_content_manager_configuration_content_types::api::new-dataset-suggestion.new-dataset-suggestion",
   "value": {
-    "uid": "api::layer.layer",
+    "uid": "api::new-dataset-suggestion.new-dataset-suggestion",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
-      "pageSize": 20,
+      "pageSize": 10,
       "mainField": "name",
       "defaultSortBy": "name",
       "defaultSortOrder": "ASC"
@@ -34,79 +34,23 @@
           "sortable": true
         }
       },
-      "type": {
+      "datum": {
         "edit": {
-          "label": "type",
+          "label": "datum",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "type",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "config": {
-        "edit": {
-          "label": "config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "config",
+          "label": "datum",
           "searchable": false,
           "sortable": false
         }
       },
-      "params_config": {
+      "category": {
         "edit": {
-          "label": "params_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "params_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "legend_config": {
-        "edit": {
-          "label": "legend_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "legend_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "interaction_config": {
-        "edit": {
-          "label": "interaction_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "interaction_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "dataset": {
-        "edit": {
-          "label": "dataset",
+          "label": "category",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -114,14 +58,28 @@
           "mainField": "name"
         },
         "list": {
-          "label": "dataset",
+          "label": "category",
           "searchable": true,
           "sortable": true
         }
       },
-      "new_dataset_suggestion": {
+      "description": {
         "edit": {
-          "label": "new_dataset_suggestion",
+          "label": "description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "layers": {
+        "edit": {
+          "label": "layers",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -129,22 +87,49 @@
           "mainField": "name"
         },
         "list": {
-          "label": "new_dataset_suggestion",
+          "label": "layers",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "unit": {
+        "edit": {
+          "label": "unit",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "unit",
           "searchable": true,
           "sortable": true
         }
       },
-      "dataset_edit_suggestion": {
+      "value_type": {
         "edit": {
-          "label": "dataset_edit_suggestion",
+          "label": "value_type",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "name"
+          "editable": true
         },
         "list": {
-          "label": "dataset_edit_suggestion",
+          "label": "value_type",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "review_status": {
+        "edit": {
+          "label": "review_status",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "review_status",
           "searchable": true,
           "sortable": true
         }
@@ -212,8 +197,8 @@
       "list": [
         "id",
         "name",
-        "type",
-        "updatedAt"
+        "category",
+        "layers"
       ],
       "edit": [
         [
@@ -224,47 +209,39 @@
         ],
         [
           {
-            "name": "type",
+            "name": "datum",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "category",
             "size": 6
           }
         ],
         [
           {
-            "name": "dataset",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "config",
+            "name": "description",
             "size": 12
           }
         ],
         [
           {
-            "name": "params_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "legend_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "interaction_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "new_dataset_suggestion",
+            "name": "layers",
             "size": 6
           },
           {
-            "name": "dataset_edit_suggestion",
+            "name": "unit",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "value_type",
+            "size": 6
+          },
+          {
+            "name": "review_status",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##new-project-suggestion.new-project-suggestion.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##new-project-suggestion.new-project-suggestion.json
@@ -1,12 +1,12 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::layer.layer",
+  "key": "plugin_content_manager_configuration_content_types::api::new-project-suggestion.new-project-suggestion",
   "value": {
-    "uid": "api::layer.layer",
+    "uid": "api::new-project-suggestion.new-project-suggestion",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
-      "pageSize": 20,
+      "pageSize": 10,
       "mainField": "name",
       "defaultSortBy": "name",
       "defaultSortOrder": "ASC"
@@ -34,79 +34,9 @@
           "sortable": true
         }
       },
-      "type": {
+      "countries": {
         "edit": {
-          "label": "type",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "type",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "config": {
-        "edit": {
-          "label": "config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "params_config": {
-        "edit": {
-          "label": "params_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "params_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "legend_config": {
-        "edit": {
-          "label": "legend_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "legend_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "interaction_config": {
-        "edit": {
-          "label": "interaction_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "interaction_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "dataset": {
-        "edit": {
-          "label": "dataset",
+          "label": "countries",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -114,14 +44,14 @@
           "mainField": "name"
         },
         "list": {
-          "label": "dataset",
-          "searchable": true,
-          "sortable": true
+          "label": "countries",
+          "searchable": false,
+          "sortable": false
         }
       },
-      "new_dataset_suggestion": {
+      "pillar": {
         "edit": {
-          "label": "new_dataset_suggestion",
+          "label": "pillar",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -129,14 +59,56 @@
           "mainField": "name"
         },
         "list": {
-          "label": "new_dataset_suggestion",
+          "label": "pillar",
           "searchable": true,
           "sortable": true
         }
       },
-      "dataset_edit_suggestion": {
+      "highlight": {
         "edit": {
-          "label": "dataset_edit_suggestion",
+          "label": "highlight",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "highlight",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "account": {
+        "edit": {
+          "label": "account",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "account",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "amount": {
+        "edit": {
+          "label": "amount",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "amount",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "sdgs": {
+        "edit": {
+          "label": "sdgs",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -144,7 +116,105 @@
           "mainField": "name"
         },
         "list": {
-          "label": "dataset_edit_suggestion",
+          "label": "sdgs",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "status": {
+        "edit": {
+          "label": "status",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "status",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "funding": {
+        "edit": {
+          "label": "funding",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "funding",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "source_country": {
+        "edit": {
+          "label": "source_country",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "source_country",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "organization_type": {
+        "edit": {
+          "label": "organization_type",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "organization_type",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "objective": {
+        "edit": {
+          "label": "objective",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "objective",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "info": {
+        "edit": {
+          "label": "info",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "info",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "review_status": {
+        "edit": {
+          "label": "review_status",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "review_status",
           "searchable": true,
           "sortable": true
         }
@@ -212,59 +282,79 @@
       "list": [
         "id",
         "name",
-        "type",
-        "updatedAt"
+        "countries",
+        "pillar"
       ],
       "edit": [
         [
           {
             "name": "name",
             "size": 6
-          }
-        ],
-        [
+          },
           {
-            "name": "type",
+            "name": "countries",
             "size": 6
           }
         ],
         [
           {
-            "name": "dataset",
+            "name": "pillar",
             "size": 6
           }
         ],
         [
           {
-            "name": "config",
+            "name": "highlight",
             "size": 12
           }
         ],
         [
           {
-            "name": "params_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "legend_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "interaction_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "new_dataset_suggestion",
+            "name": "account",
             "size": 6
           },
           {
-            "name": "dataset_edit_suggestion",
+            "name": "amount",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "sdgs",
+            "size": 6
+          },
+          {
+            "name": "status",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "funding",
+            "size": 6
+          },
+          {
+            "name": "source_country",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "organization_type",
+            "size": 6
+          },
+          {
+            "name": "objective",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "info",
+            "size": 6
+          },
+          {
+            "name": "review_status",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##new-tool-suggestion.new-tool-suggestion.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##new-tool-suggestion.new-tool-suggestion.json
@@ -1,12 +1,12 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::layer.layer",
+  "key": "plugin_content_manager_configuration_content_types::api::new-tool-suggestion.new-tool-suggestion",
   "value": {
-    "uid": "api::layer.layer",
+    "uid": "api::new-tool-suggestion.new-tool-suggestion",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
-      "pageSize": 20,
+      "pageSize": 10,
       "mainField": "name",
       "defaultSortBy": "name",
       "defaultSortOrder": "ASC"
@@ -34,79 +34,37 @@
           "sortable": true
         }
       },
-      "type": {
+      "description": {
         "edit": {
-          "label": "type",
+          "label": "description",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "type",
+          "label": "description",
           "searchable": true,
           "sortable": true
         }
       },
-      "config": {
+      "link": {
         "edit": {
-          "label": "config",
+          "label": "link",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "config",
-          "searchable": false,
-          "sortable": false
+          "label": "link",
+          "searchable": true,
+          "sortable": true
         }
       },
-      "params_config": {
+      "other_tools_category": {
         "edit": {
-          "label": "params_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "params_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "legend_config": {
-        "edit": {
-          "label": "legend_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "legend_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "interaction_config": {
-        "edit": {
-          "label": "interaction_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "interaction_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "dataset": {
-        "edit": {
-          "label": "dataset",
+          "label": "other_tools_category",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -114,37 +72,21 @@
           "mainField": "name"
         },
         "list": {
-          "label": "dataset",
+          "label": "other_tools_category",
           "searchable": true,
           "sortable": true
         }
       },
-      "new_dataset_suggestion": {
+      "review_status": {
         "edit": {
-          "label": "new_dataset_suggestion",
+          "label": "review_status",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "name"
+          "editable": true
         },
         "list": {
-          "label": "new_dataset_suggestion",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "dataset_edit_suggestion": {
-        "edit": {
-          "label": "dataset_edit_suggestion",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "dataset_edit_suggestion",
+          "label": "review_status",
           "searchable": true,
           "sortable": true
         }
@@ -212,59 +154,33 @@
       "list": [
         "id",
         "name",
-        "type",
-        "updatedAt"
+        "description",
+        "link"
       ],
       "edit": [
         [
           {
             "name": "name",
             "size": 6
-          }
-        ],
-        [
+          },
           {
-            "name": "type",
+            "name": "description",
             "size": 6
           }
         ],
         [
           {
-            "name": "dataset",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "params_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "legend_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "interaction_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "new_dataset_suggestion",
+            "name": "link",
             "size": 6
           },
           {
-            "name": "dataset_edit_suggestion",
+            "name": "other_tools_category",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "review_status",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##other-tool.other-tool.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##other-tool.other-tool.json
@@ -77,6 +77,21 @@
           "sortable": true
         }
       },
+      "tool_edit_suggestions": {
+        "edit": {
+          "label": "tool_edit_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "tool_edit_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -161,6 +176,12 @@
           },
           {
             "name": "other_tools_category",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "tool_edit_suggestions",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##pillar.pillar.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##pillar.pillar.json
@@ -63,6 +63,36 @@
           "sortable": false
         }
       },
+      "new_project_suggestions": {
+        "edit": {
+          "label": "new_project_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "new_project_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "project_edit_suggestions": {
+        "edit": {
+          "label": "project_edit_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "project_edit_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -146,6 +176,16 @@
           {
             "name": "description",
             "size": 12
+          }
+        ],
+        [
+          {
+            "name": "new_project_suggestions",
+            "size": 6
+          },
+          {
+            "name": "project_edit_suggestions",
+            "size": 6
           }
         ]
       ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project-edit-suggestion.project-edit-suggestion.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project-edit-suggestion.project-edit-suggestion.json
@@ -1,12 +1,12 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::layer.layer",
+  "key": "plugin_content_manager_configuration_content_types::api::project-edit-suggestion.project-edit-suggestion",
   "value": {
-    "uid": "api::layer.layer",
+    "uid": "api::project-edit-suggestion.project-edit-suggestion",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
-      "pageSize": 20,
+      "pageSize": 10,
       "mainField": "name",
       "defaultSortBy": "name",
       "defaultSortOrder": "ASC"
@@ -34,79 +34,9 @@
           "sortable": true
         }
       },
-      "type": {
+      "countries": {
         "edit": {
-          "label": "type",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "type",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "config": {
-        "edit": {
-          "label": "config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "params_config": {
-        "edit": {
-          "label": "params_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "params_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "legend_config": {
-        "edit": {
-          "label": "legend_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "legend_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "interaction_config": {
-        "edit": {
-          "label": "interaction_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "interaction_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "dataset": {
-        "edit": {
-          "label": "dataset",
+          "label": "countries",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -114,14 +44,14 @@
           "mainField": "name"
         },
         "list": {
-          "label": "dataset",
-          "searchable": true,
-          "sortable": true
+          "label": "countries",
+          "searchable": false,
+          "sortable": false
         }
       },
-      "new_dataset_suggestion": {
+      "pillar": {
         "edit": {
-          "label": "new_dataset_suggestion",
+          "label": "pillar",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -129,14 +59,56 @@
           "mainField": "name"
         },
         "list": {
-          "label": "new_dataset_suggestion",
+          "label": "pillar",
           "searchable": true,
           "sortable": true
         }
       },
-      "dataset_edit_suggestion": {
+      "highlight": {
         "edit": {
-          "label": "dataset_edit_suggestion",
+          "label": "highlight",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "highlight",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "account": {
+        "edit": {
+          "label": "account",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "account",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "amount": {
+        "edit": {
+          "label": "amount",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "amount",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "sdgs": {
+        "edit": {
+          "label": "sdgs",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -144,7 +116,120 @@
           "mainField": "name"
         },
         "list": {
-          "label": "dataset_edit_suggestion",
+          "label": "sdgs",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "status": {
+        "edit": {
+          "label": "status",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "status",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "funding": {
+        "edit": {
+          "label": "funding",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "funding",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "source_country": {
+        "edit": {
+          "label": "source_country",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "source_country",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "organization_type": {
+        "edit": {
+          "label": "organization_type",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "organization_type",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "objective": {
+        "edit": {
+          "label": "objective",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "objective",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "info": {
+        "edit": {
+          "label": "info",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "info",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "review_status": {
+        "edit": {
+          "label": "review_status",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "review_status",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "project": {
+        "edit": {
+          "label": "project",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "project",
           "searchable": true,
           "sortable": true
         }
@@ -212,59 +297,85 @@
       "list": [
         "id",
         "name",
-        "type",
-        "updatedAt"
+        "countries",
+        "pillar"
       ],
       "edit": [
         [
           {
             "name": "name",
             "size": 6
-          }
-        ],
-        [
+          },
           {
-            "name": "type",
+            "name": "countries",
             "size": 6
           }
         ],
         [
           {
-            "name": "dataset",
+            "name": "pillar",
             "size": 6
           }
         ],
         [
           {
-            "name": "config",
+            "name": "highlight",
             "size": 12
           }
         ],
         [
           {
-            "name": "params_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "legend_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "interaction_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "new_dataset_suggestion",
+            "name": "account",
             "size": 6
           },
           {
-            "name": "dataset_edit_suggestion",
+            "name": "amount",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "sdgs",
+            "size": 6
+          },
+          {
+            "name": "status",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "funding",
+            "size": 6
+          },
+          {
+            "name": "source_country",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "organization_type",
+            "size": 6
+          },
+          {
+            "name": "objective",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "info",
+            "size": 6
+          },
+          {
+            "name": "review_status",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "project",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
@@ -149,6 +149,77 @@
           "sortable": true
         }
       },
+      "source_country": {
+        "edit": {
+          "label": "source_country",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "source_country",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "organization_type": {
+        "edit": {
+          "label": "organization_type",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "organization_type",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "objective": {
+        "edit": {
+          "label": "objective",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "objective",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "info": {
+        "edit": {
+          "label": "info",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "info",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "project_edit_suggestions": {
+        "edit": {
+          "label": "project_edit_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "project_edit_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -265,6 +336,30 @@
         [
           {
             "name": "funding",
+            "size": 6
+          },
+          {
+            "name": "source_country",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "organization_type",
+            "size": 6
+          },
+          {
+            "name": "objective",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "info",
+            "size": 6
+          },
+          {
+            "name": "project_edit_suggestions",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##sdg.sdg.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##sdg.sdg.json
@@ -49,6 +49,36 @@
           "sortable": false
         }
       },
+      "new_project_suggestions": {
+        "edit": {
+          "label": "new_project_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "new_project_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "project_edit_suggestions": {
+        "edit": {
+          "label": "project_edit_suggestions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "project_edit_suggestions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -123,6 +153,16 @@
           },
           {
             "name": "projects",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "new_project_suggestions",
+            "size": 6
+          },
+          {
+            "name": "project_edit_suggestions",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##tool-edit-suggestion.tool-edit-suggestion.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##tool-edit-suggestion.tool-edit-suggestion.json
@@ -1,12 +1,12 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::layer.layer",
+  "key": "plugin_content_manager_configuration_content_types::api::tool-edit-suggestion.tool-edit-suggestion",
   "value": {
-    "uid": "api::layer.layer",
+    "uid": "api::tool-edit-suggestion.tool-edit-suggestion",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
-      "pageSize": 20,
+      "pageSize": 10,
       "mainField": "name",
       "defaultSortBy": "name",
       "defaultSortOrder": "ASC"
@@ -34,79 +34,37 @@
           "sortable": true
         }
       },
-      "type": {
+      "description": {
         "edit": {
-          "label": "type",
+          "label": "description",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "type",
+          "label": "description",
           "searchable": true,
           "sortable": true
         }
       },
-      "config": {
+      "link": {
         "edit": {
-          "label": "config",
+          "label": "link",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "config",
-          "searchable": false,
-          "sortable": false
+          "label": "link",
+          "searchable": true,
+          "sortable": true
         }
       },
-      "params_config": {
+      "other_tools_category": {
         "edit": {
-          "label": "params_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "params_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "legend_config": {
-        "edit": {
-          "label": "legend_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "legend_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "interaction_config": {
-        "edit": {
-          "label": "interaction_config",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "interaction_config",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "dataset": {
-        "edit": {
-          "label": "dataset",
+          "label": "other_tools_category",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -114,14 +72,14 @@
           "mainField": "name"
         },
         "list": {
-          "label": "dataset",
+          "label": "other_tools_category",
           "searchable": true,
           "sortable": true
         }
       },
-      "new_dataset_suggestion": {
+      "other_tool": {
         "edit": {
-          "label": "new_dataset_suggestion",
+          "label": "other_tool",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -129,22 +87,21 @@
           "mainField": "name"
         },
         "list": {
-          "label": "new_dataset_suggestion",
+          "label": "other_tool",
           "searchable": true,
           "sortable": true
         }
       },
-      "dataset_edit_suggestion": {
+      "review_status": {
         "edit": {
-          "label": "dataset_edit_suggestion",
+          "label": "review_status",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "name"
+          "editable": true
         },
         "list": {
-          "label": "dataset_edit_suggestion",
+          "label": "review_status",
           "searchable": true,
           "sortable": true
         }
@@ -212,59 +169,37 @@
       "list": [
         "id",
         "name",
-        "type",
-        "updatedAt"
+        "description",
+        "link"
       ],
       "edit": [
         [
           {
             "name": "name",
             "size": 6
-          }
-        ],
-        [
+          },
           {
-            "name": "type",
+            "name": "description",
             "size": 6
           }
         ],
         [
           {
-            "name": "dataset",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "params_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "legend_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "interaction_config",
-            "size": 12
-          }
-        ],
-        [
-          {
-            "name": "new_dataset_suggestion",
+            "name": "link",
             "size": 6
           },
           {
-            "name": "dataset_edit_suggestion",
+            "name": "other_tools_category",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "other_tool",
+            "size": 6
+          },
+          {
+            "name": "review_status",
             "size": 6
           }
         ]

--- a/cms/config/sync/user-role.admin.json
+++ b/cms/config/sync/user-role.admin.json
@@ -1,0 +1,421 @@
+{
+  "name": "Admin",
+  "description": "Have all the permissions",
+  "type": "admin",
+  "permissions": [
+    {
+      "action": "api::category.category.create"
+    },
+    {
+      "action": "api::category.category.delete"
+    },
+    {
+      "action": "api::category.category.find"
+    },
+    {
+      "action": "api::category.category.findOne"
+    },
+    {
+      "action": "api::category.category.update"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.create"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.delete"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.find"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.findOne"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.update"
+    },
+    {
+      "action": "api::collaborator.collaborator.create"
+    },
+    {
+      "action": "api::collaborator.collaborator.delete"
+    },
+    {
+      "action": "api::collaborator.collaborator.find"
+    },
+    {
+      "action": "api::collaborator.collaborator.findOne"
+    },
+    {
+      "action": "api::collaborator.collaborator.update"
+    },
+    {
+      "action": "api::country.country.create"
+    },
+    {
+      "action": "api::country.country.delete"
+    },
+    {
+      "action": "api::country.country.find"
+    },
+    {
+      "action": "api::country.country.findOne"
+    },
+    {
+      "action": "api::country.country.update"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.create"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.delete"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.find"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.findOne"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.update"
+    },
+    {
+      "action": "api::dataset-value.dataset-value.create"
+    },
+    {
+      "action": "api::dataset-value.dataset-value.delete"
+    },
+    {
+      "action": "api::dataset-value.dataset-value.find"
+    },
+    {
+      "action": "api::dataset-value.dataset-value.findOne"
+    },
+    {
+      "action": "api::dataset-value.dataset-value.update"
+    },
+    {
+      "action": "api::dataset.dataset.create"
+    },
+    {
+      "action": "api::dataset.dataset.delete"
+    },
+    {
+      "action": "api::dataset.dataset.find"
+    },
+    {
+      "action": "api::dataset.dataset.findOne"
+    },
+    {
+      "action": "api::dataset.dataset.update"
+    },
+    {
+      "action": "api::download-email.download-email.create"
+    },
+    {
+      "action": "api::download-email.download-email.delete"
+    },
+    {
+      "action": "api::download-email.download-email.find"
+    },
+    {
+      "action": "api::download-email.download-email.findOne"
+    },
+    {
+      "action": "api::download-email.download-email.update"
+    },
+    {
+      "action": "api::layer.layer.create"
+    },
+    {
+      "action": "api::layer.layer.delete"
+    },
+    {
+      "action": "api::layer.layer.find"
+    },
+    {
+      "action": "api::layer.layer.findOne"
+    },
+    {
+      "action": "api::layer.layer.update"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.create"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.delete"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.find"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.findOne"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.update"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.create"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.delete"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.find"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.findOne"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.update"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.create"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.delete"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.find"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.findOne"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.update"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.create"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.delete"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.find"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.findOne"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.update"
+    },
+    {
+      "action": "api::other-tool.other-tool.create"
+    },
+    {
+      "action": "api::other-tool.other-tool.delete"
+    },
+    {
+      "action": "api::other-tool.other-tool.find"
+    },
+    {
+      "action": "api::other-tool.other-tool.findOne"
+    },
+    {
+      "action": "api::other-tool.other-tool.update"
+    },
+    {
+      "action": "api::other-tools-category.other-tools-category.create"
+    },
+    {
+      "action": "api::other-tools-category.other-tools-category.delete"
+    },
+    {
+      "action": "api::other-tools-category.other-tools-category.find"
+    },
+    {
+      "action": "api::other-tools-category.other-tools-category.findOne"
+    },
+    {
+      "action": "api::other-tools-category.other-tools-category.update"
+    },
+    {
+      "action": "api::pillar.pillar.create"
+    },
+    {
+      "action": "api::pillar.pillar.delete"
+    },
+    {
+      "action": "api::pillar.pillar.find"
+    },
+    {
+      "action": "api::pillar.pillar.findOne"
+    },
+    {
+      "action": "api::pillar.pillar.update"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.create"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.delete"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.find"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.findOne"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.update"
+    },
+    {
+      "action": "api::project.project.create"
+    },
+    {
+      "action": "api::project.project.delete"
+    },
+    {
+      "action": "api::project.project.find"
+    },
+    {
+      "action": "api::project.project.findOne"
+    },
+    {
+      "action": "api::project.project.update"
+    },
+    {
+      "action": "api::resource.resource.create"
+    },
+    {
+      "action": "api::resource.resource.delete"
+    },
+    {
+      "action": "api::resource.resource.find"
+    },
+    {
+      "action": "api::resource.resource.findOne"
+    },
+    {
+      "action": "api::resource.resource.update"
+    },
+    {
+      "action": "api::sdg.sdg.create"
+    },
+    {
+      "action": "api::sdg.sdg.delete"
+    },
+    {
+      "action": "api::sdg.sdg.find"
+    },
+    {
+      "action": "api::sdg.sdg.findOne"
+    },
+    {
+      "action": "api::sdg.sdg.update"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.create"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.delete"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.find"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.findOne"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.update"
+    },
+    {
+      "action": "plugin::content-type-builder.components.getComponent"
+    },
+    {
+      "action": "plugin::content-type-builder.components.getComponents"
+    },
+    {
+      "action": "plugin::content-type-builder.content-types.getContentType"
+    },
+    {
+      "action": "plugin::content-type-builder.content-types.getContentTypes"
+    },
+    {
+      "action": "plugin::email.email.send"
+    },
+    {
+      "action": "plugin::i18n.locales.listLocales"
+    },
+    {
+      "action": "plugin::import-export-entries.export.exportData"
+    },
+    {
+      "action": "plugin::import-export-entries.import.importData"
+    },
+    {
+      "action": "plugin::upload.content-api.destroy"
+    },
+    {
+      "action": "plugin::upload.content-api.find"
+    },
+    {
+      "action": "plugin::upload.content-api.findOne"
+    },
+    {
+      "action": "plugin::upload.content-api.upload"
+    },
+    {
+      "action": "plugin::users-permissions.auth.callback"
+    },
+    {
+      "action": "plugin::users-permissions.auth.changePassword"
+    },
+    {
+      "action": "plugin::users-permissions.auth.connect"
+    },
+    {
+      "action": "plugin::users-permissions.auth.emailConfirmation"
+    },
+    {
+      "action": "plugin::users-permissions.auth.forgotPassword"
+    },
+    {
+      "action": "plugin::users-permissions.auth.register"
+    },
+    {
+      "action": "plugin::users-permissions.auth.resetPassword"
+    },
+    {
+      "action": "plugin::users-permissions.auth.sendEmailConfirmation"
+    },
+    {
+      "action": "plugin::users-permissions.permissions.getPermissions"
+    },
+    {
+      "action": "plugin::users-permissions.role.createRole"
+    },
+    {
+      "action": "plugin::users-permissions.role.deleteRole"
+    },
+    {
+      "action": "plugin::users-permissions.role.find"
+    },
+    {
+      "action": "plugin::users-permissions.role.findOne"
+    },
+    {
+      "action": "plugin::users-permissions.role.updateRole"
+    },
+    {
+      "action": "plugin::users-permissions.user.count"
+    },
+    {
+      "action": "plugin::users-permissions.user.create"
+    },
+    {
+      "action": "plugin::users-permissions.user.destroy"
+    },
+    {
+      "action": "plugin::users-permissions.user.find"
+    },
+    {
+      "action": "plugin::users-permissions.user.findOne"
+    },
+    {
+      "action": "plugin::users-permissions.user.me"
+    },
+    {
+      "action": "plugin::users-permissions.user.update"
+    }
+  ]
+}

--- a/cms/config/sync/user-role.contributor.json
+++ b/cms/config/sync/user-role.contributor.json
@@ -1,0 +1,199 @@
+{
+  "name": "Contributor",
+  "description": "Can create, edit and delete new and edit suggestions for Project, Collaborator, Dataset and Tool.",
+  "type": "contributor",
+  "permissions": [
+    {
+      "action": "api::category.category.find"
+    },
+    {
+      "action": "api::category.category.findOne"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.create"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.delete"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.find"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.findOne"
+    },
+    {
+      "action": "api::collaborator-edit-suggestion.collaborator-edit-suggestion.update"
+    },
+    {
+      "action": "api::collaborator.collaborator.find"
+    },
+    {
+      "action": "api::collaborator.collaborator.findOne"
+    },
+    {
+      "action": "api::country.country.find"
+    },
+    {
+      "action": "api::country.country.findOne"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.create"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.delete"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.find"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.findOne"
+    },
+    {
+      "action": "api::dataset-edit-suggestion.dataset-edit-suggestion.update"
+    },
+    {
+      "action": "api::dataset-value.dataset-value.find"
+    },
+    {
+      "action": "api::dataset-value.dataset-value.findOne"
+    },
+    {
+      "action": "api::dataset.dataset.find"
+    },
+    {
+      "action": "api::dataset.dataset.findOne"
+    },
+    {
+      "action": "api::layer.layer.find"
+    },
+    {
+      "action": "api::layer.layer.findOne"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.create"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.delete"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.find"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.findOne"
+    },
+    {
+      "action": "api::new-collaborator-suggestion.new-collaborator-suggestion.update"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.create"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.delete"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.find"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.findOne"
+    },
+    {
+      "action": "api::new-dataset-suggestion.new-dataset-suggestion.update"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.create"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.delete"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.find"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.findOne"
+    },
+    {
+      "action": "api::new-project-suggestion.new-project-suggestion.update"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.create"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.delete"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.find"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.findOne"
+    },
+    {
+      "action": "api::new-tool-suggestion.new-tool-suggestion.update"
+    },
+    {
+      "action": "api::other-tool.other-tool.find"
+    },
+    {
+      "action": "api::other-tool.other-tool.findOne"
+    },
+    {
+      "action": "api::other-tools-category.other-tools-category.find"
+    },
+    {
+      "action": "api::other-tools-category.other-tools-category.findOne"
+    },
+    {
+      "action": "api::pillar.pillar.find"
+    },
+    {
+      "action": "api::pillar.pillar.findOne"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.create"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.delete"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.find"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.findOne"
+    },
+    {
+      "action": "api::project-edit-suggestion.project-edit-suggestion.update"
+    },
+    {
+      "action": "api::project.project.find"
+    },
+    {
+      "action": "api::project.project.findOne"
+    },
+    {
+      "action": "api::resource.resource.find"
+    },
+    {
+      "action": "api::resource.resource.findOne"
+    },
+    {
+      "action": "api::sdg.sdg.find"
+    },
+    {
+      "action": "api::sdg.sdg.findOne"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.create"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.delete"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.find"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.findOne"
+    },
+    {
+      "action": "api::tool-edit-suggestion.tool-edit-suggestion.update"
+    }
+  ]
+}

--- a/cms/src/api/category/content-types/category/schema.json
+++ b/cms/src/api/category/content-types/category/schema.json
@@ -22,6 +22,18 @@
       "relation": "oneToMany",
       "target": "api::dataset.dataset",
       "mappedBy": "category"
+    },
+    "new_dataset_suggestions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::new-dataset-suggestion.new-dataset-suggestion",
+      "mappedBy": "category"
+    },
+    "dataset_edit_suggestions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::dataset-edit-suggestion.dataset-edit-suggestion",
+      "mappedBy": "category"
     }
   }
 }

--- a/cms/src/api/collaborator-edit-suggestion/content-types/collaborator-edit-suggestion/schema.json
+++ b/cms/src/api/collaborator-edit-suggestion/content-types/collaborator-edit-suggestion/schema.json
@@ -1,0 +1,44 @@
+{
+  "kind": "collectionType",
+  "collectionName": "collaborator_edit_suggestions",
+  "info": {
+    "singularName": "collaborator-edit-suggestion",
+    "pluralName": "collaborator-edit-suggestions",
+    "displayName": "Collaborator Edit Suggestion"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "link": {
+      "type": "string"
+    },
+    "type": {
+      "type": "enumeration",
+      "enum": [
+        "donor",
+        "collaborator"
+      ]
+    },
+    "collaborator": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::collaborator.collaborator",
+      "inversedBy": "collaborator_edit_suggestions"
+    },
+    "review_status": {
+      "type": "enumeration",
+      "enum": [
+        "pending",
+        "approved",
+        "declined"
+      ],
+      "required": true,
+      "default": "pending"
+    }
+  }
+}

--- a/cms/src/api/collaborator-edit-suggestion/controllers/collaborator-edit-suggestion.ts
+++ b/cms/src/api/collaborator-edit-suggestion/controllers/collaborator-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * collaborator-edit-suggestion controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::collaborator-edit-suggestion.collaborator-edit-suggestion');

--- a/cms/src/api/collaborator-edit-suggestion/documentation/1.0.0/collaborator-edit-suggestion.json
+++ b/cms/src/api/collaborator-edit-suggestion/documentation/1.0.0/collaborator-edit-suggestion.json
@@ -1,0 +1,507 @@
+{
+  "/collaborator-edit-suggestions": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollaboratorEditSuggestionListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Collaborator-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/collaborator-edit-suggestions"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollaboratorEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Collaborator-edit-suggestion"
+      ],
+      "parameters": [],
+      "operationId": "post/collaborator-edit-suggestions",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CollaboratorEditSuggestionRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/collaborator-edit-suggestions/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollaboratorEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Collaborator-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/collaborator-edit-suggestions/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollaboratorEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Collaborator-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/collaborator-edit-suggestions/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CollaboratorEditSuggestionRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Collaborator-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/collaborator-edit-suggestions/{id}"
+    }
+  }
+}

--- a/cms/src/api/collaborator-edit-suggestion/routes/collaborator-edit-suggestion.ts
+++ b/cms/src/api/collaborator-edit-suggestion/routes/collaborator-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * collaborator-edit-suggestion router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::collaborator-edit-suggestion.collaborator-edit-suggestion');

--- a/cms/src/api/collaborator-edit-suggestion/services/collaborator-edit-suggestion.ts
+++ b/cms/src/api/collaborator-edit-suggestion/services/collaborator-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * collaborator-edit-suggestion service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::collaborator-edit-suggestion.collaborator-edit-suggestion');

--- a/cms/src/api/dataset-edit-suggestion/content-types/dataset-edit-suggestion/schema.json
+++ b/cms/src/api/dataset-edit-suggestion/content-types/dataset-edit-suggestion/schema.json
@@ -1,10 +1,10 @@
 {
   "kind": "collectionType",
-  "collectionName": "datasets",
+  "collectionName": "dataset_edit_suggestions",
   "info": {
-    "singularName": "dataset",
-    "pluralName": "datasets",
-    "displayName": "Dataset",
+    "singularName": "dataset-edit-suggestion",
+    "pluralName": "dataset-edit-suggestions",
+    "displayName": "Dataset Edit Suggestion",
     "description": ""
   },
   "options": {
@@ -13,32 +13,28 @@
   "pluginOptions": {},
   "attributes": {
     "name": {
-      "type": "string",
-      "required": true
+      "type": "string"
     },
     "datum": {
-      "type": "json",
-      "required": true
+      "type": "json"
     },
     "category": {
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::category.category",
-      "inversedBy": "datasets"
+      "inversedBy": "dataset_edit_suggestions"
     },
     "description": {
-      "type": "richtext",
-      "required": true
+      "type": "richtext"
     },
     "layers": {
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::layer.layer",
-      "mappedBy": "dataset"
+      "mappedBy": "dataset_edit_suggestion"
     },
     "unit": {
-      "type": "string",
-      "required": false
+      "type": "string"
     },
     "value_type": {
       "type": "enumeration",
@@ -47,14 +43,23 @@
         "number",
         "boolean",
         "resource"
+      ]
+    },
+    "review_status": {
+      "type": "enumeration",
+      "enum": [
+        "pending",
+        "approved",
+        "declined"
       ],
+      "default": "pending",
       "required": true
     },
-    "dataset_edit_suggestions": {
+    "dataset": {
       "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::dataset-edit-suggestion.dataset-edit-suggestion",
-      "mappedBy": "dataset"
+      "relation": "manyToOne",
+      "target": "api::dataset.dataset",
+      "inversedBy": "dataset_edit_suggestions"
     }
   }
 }

--- a/cms/src/api/dataset-edit-suggestion/controllers/dataset-edit-suggestion.ts
+++ b/cms/src/api/dataset-edit-suggestion/controllers/dataset-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * dataset-edit-suggestion controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::dataset-edit-suggestion.dataset-edit-suggestion');

--- a/cms/src/api/dataset-edit-suggestion/documentation/1.0.0/dataset-edit-suggestion.json
+++ b/cms/src/api/dataset-edit-suggestion/documentation/1.0.0/dataset-edit-suggestion.json
@@ -1,0 +1,507 @@
+{
+  "/dataset-edit-suggestions": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetEditSuggestionListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Dataset-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/dataset-edit-suggestions"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Dataset-edit-suggestion"
+      ],
+      "parameters": [],
+      "operationId": "post/dataset-edit-suggestions",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DatasetEditSuggestionRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/dataset-edit-suggestions/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Dataset-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/dataset-edit-suggestions/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Dataset-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/dataset-edit-suggestions/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DatasetEditSuggestionRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Dataset-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/dataset-edit-suggestions/{id}"
+    }
+  }
+}

--- a/cms/src/api/dataset-edit-suggestion/routes/dataset-edit-suggestion.ts
+++ b/cms/src/api/dataset-edit-suggestion/routes/dataset-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * dataset-edit-suggestion router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::dataset-edit-suggestion.dataset-edit-suggestion');

--- a/cms/src/api/dataset-edit-suggestion/services/dataset-edit-suggestion.ts
+++ b/cms/src/api/dataset-edit-suggestion/services/dataset-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * dataset-edit-suggestion service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::dataset-edit-suggestion.dataset-edit-suggestion');

--- a/cms/src/api/layer/content-types/layer/schema.json
+++ b/cms/src/api/layer/content-types/layer/schema.json
@@ -47,6 +47,18 @@
       "relation": "manyToOne",
       "target": "api::dataset.dataset",
       "inversedBy": "layers"
+    },
+    "new_dataset_suggestion": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::new-dataset-suggestion.new-dataset-suggestion",
+      "inversedBy": "layers"
+    },
+    "dataset_edit_suggestion": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::dataset-edit-suggestion.dataset-edit-suggestion",
+      "inversedBy": "layers"
     }
   }
 }

--- a/cms/src/api/new-collaborator-suggestion/content-types/new-collaborator-suggestion/schema.json
+++ b/cms/src/api/new-collaborator-suggestion/content-types/new-collaborator-suggestion/schema.json
@@ -1,11 +1,10 @@
 {
   "kind": "collectionType",
-  "collectionName": "collaborators",
+  "collectionName": "new_collaborator_suggestions",
   "info": {
-    "singularName": "collaborator",
-    "pluralName": "collaborators",
-    "displayName": "Collaborator",
-    "description": ""
+    "singularName": "new-collaborator-suggestion",
+    "pluralName": "new-collaborator-suggestions",
+    "displayName": "New Collaborator Suggestion"
   },
   "options": {
     "draftAndPublish": true
@@ -27,11 +26,15 @@
       ],
       "required": true
     },
-    "collaborator_edit_suggestions": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::collaborator-edit-suggestion.collaborator-edit-suggestion",
-      "mappedBy": "collaborator"
+    "review_status": {
+      "type": "enumeration",
+      "enum": [
+        "pending",
+        "approved",
+        "declined"
+      ],
+      "default": "pending",
+      "required": true
     }
   }
 }

--- a/cms/src/api/new-collaborator-suggestion/controllers/new-collaborator-suggestion.ts
+++ b/cms/src/api/new-collaborator-suggestion/controllers/new-collaborator-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-collaborator-suggestion controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::new-collaborator-suggestion.new-collaborator-suggestion');

--- a/cms/src/api/new-collaborator-suggestion/documentation/1.0.0/new-collaborator-suggestion.json
+++ b/cms/src/api/new-collaborator-suggestion/documentation/1.0.0/new-collaborator-suggestion.json
@@ -1,0 +1,507 @@
+{
+  "/new-collaborator-suggestions": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewCollaboratorSuggestionListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-collaborator-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/new-collaborator-suggestions"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewCollaboratorSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-collaborator-suggestion"
+      ],
+      "parameters": [],
+      "operationId": "post/new-collaborator-suggestions",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/NewCollaboratorSuggestionRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/new-collaborator-suggestions/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewCollaboratorSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-collaborator-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/new-collaborator-suggestions/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewCollaboratorSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-collaborator-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/new-collaborator-suggestions/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/NewCollaboratorSuggestionRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-collaborator-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/new-collaborator-suggestions/{id}"
+    }
+  }
+}

--- a/cms/src/api/new-collaborator-suggestion/routes/new-collaborator-suggestion.ts
+++ b/cms/src/api/new-collaborator-suggestion/routes/new-collaborator-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-collaborator-suggestion router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::new-collaborator-suggestion.new-collaborator-suggestion');

--- a/cms/src/api/new-collaborator-suggestion/services/new-collaborator-suggestion.ts
+++ b/cms/src/api/new-collaborator-suggestion/services/new-collaborator-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-collaborator-suggestion service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::new-collaborator-suggestion.new-collaborator-suggestion');

--- a/cms/src/api/new-dataset-suggestion/content-types/new-dataset-suggestion/schema.json
+++ b/cms/src/api/new-dataset-suggestion/content-types/new-dataset-suggestion/schema.json
@@ -1,10 +1,10 @@
 {
   "kind": "collectionType",
-  "collectionName": "datasets",
+  "collectionName": "new_dataset_suggestions",
   "info": {
-    "singularName": "dataset",
-    "pluralName": "datasets",
-    "displayName": "Dataset",
+    "singularName": "new-dataset-suggestion",
+    "pluralName": "new-dataset-suggestions",
+    "displayName": "New Dataset Suggestion",
     "description": ""
   },
   "options": {
@@ -24,7 +24,7 @@
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::category.category",
-      "inversedBy": "datasets"
+      "inversedBy": "new_dataset_suggestions"
     },
     "description": {
       "type": "richtext",
@@ -34,11 +34,10 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::layer.layer",
-      "mappedBy": "dataset"
+      "mappedBy": "new_dataset_suggestion"
     },
     "unit": {
-      "type": "string",
-      "required": false
+      "type": "string"
     },
     "value_type": {
       "type": "enumeration",
@@ -50,11 +49,15 @@
       ],
       "required": true
     },
-    "dataset_edit_suggestions": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::dataset-edit-suggestion.dataset-edit-suggestion",
-      "mappedBy": "dataset"
+    "review_status": {
+      "type": "enumeration",
+      "enum": [
+        "pending",
+        "approved",
+        "declined"
+      ],
+      "default": "pending",
+      "required": true
     }
   }
 }

--- a/cms/src/api/new-dataset-suggestion/controllers/new-dataset-suggestion.ts
+++ b/cms/src/api/new-dataset-suggestion/controllers/new-dataset-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-dataset-suggestion controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::new-dataset-suggestion.new-dataset-suggestion');

--- a/cms/src/api/new-dataset-suggestion/documentation/1.0.0/new-dataset-suggestion.json
+++ b/cms/src/api/new-dataset-suggestion/documentation/1.0.0/new-dataset-suggestion.json
@@ -1,0 +1,507 @@
+{
+  "/new-dataset-suggestions": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewDatasetSuggestionListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-dataset-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/new-dataset-suggestions"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewDatasetSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-dataset-suggestion"
+      ],
+      "parameters": [],
+      "operationId": "post/new-dataset-suggestions",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/NewDatasetSuggestionRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/new-dataset-suggestions/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewDatasetSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-dataset-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/new-dataset-suggestions/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewDatasetSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-dataset-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/new-dataset-suggestions/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/NewDatasetSuggestionRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-dataset-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/new-dataset-suggestions/{id}"
+    }
+  }
+}

--- a/cms/src/api/new-dataset-suggestion/routes/new-dataset-suggestion.ts
+++ b/cms/src/api/new-dataset-suggestion/routes/new-dataset-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-dataset-suggestion router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::new-dataset-suggestion.new-dataset-suggestion');

--- a/cms/src/api/new-dataset-suggestion/services/new-dataset-suggestion.ts
+++ b/cms/src/api/new-dataset-suggestion/services/new-dataset-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-dataset-suggestion service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::new-dataset-suggestion.new-dataset-suggestion');

--- a/cms/src/api/new-project-suggestion/content-types/new-project-suggestion/schema.json
+++ b/cms/src/api/new-project-suggestion/content-types/new-project-suggestion/schema.json
@@ -1,10 +1,10 @@
 {
   "kind": "collectionType",
-  "collectionName": "projects",
+  "collectionName": "new_project_suggestions",
   "info": {
-    "singularName": "project",
-    "pluralName": "projects",
-    "displayName": "Project",
+    "singularName": "new-project-suggestion",
+    "pluralName": "new-project-suggestions",
+    "displayName": "New Project Suggestion",
     "description": ""
   },
   "options": {
@@ -25,7 +25,7 @@
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::pillar.pillar",
-      "inversedBy": "projects"
+      "inversedBy": "new_project_suggestions"
     },
     "highlight": {
       "type": "richtext"
@@ -40,7 +40,7 @@
       "type": "relation",
       "relation": "manyToMany",
       "target": "api::sdg.sdg",
-      "inversedBy": "projects"
+      "inversedBy": "new_project_suggestions"
     },
     "status": {
       "type": "string"
@@ -60,11 +60,15 @@
     "info": {
       "type": "string"
     },
-    "project_edit_suggestions": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::project-edit-suggestion.project-edit-suggestion",
-      "mappedBy": "project"
+    "review_status": {
+      "type": "enumeration",
+      "enum": [
+        "pending",
+        "approved",
+        "declined"
+      ],
+      "default": "pending",
+      "required": true
     }
   }
 }

--- a/cms/src/api/new-project-suggestion/controllers/new-project-suggestion.ts
+++ b/cms/src/api/new-project-suggestion/controllers/new-project-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-project-suggestion controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::new-project-suggestion.new-project-suggestion');

--- a/cms/src/api/new-project-suggestion/documentation/1.0.0/new-project-suggestion.json
+++ b/cms/src/api/new-project-suggestion/documentation/1.0.0/new-project-suggestion.json
@@ -1,0 +1,507 @@
+{
+  "/new-project-suggestions": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewProjectSuggestionListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-project-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/new-project-suggestions"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewProjectSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-project-suggestion"
+      ],
+      "parameters": [],
+      "operationId": "post/new-project-suggestions",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/NewProjectSuggestionRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/new-project-suggestions/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewProjectSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-project-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/new-project-suggestions/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewProjectSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-project-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/new-project-suggestions/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/NewProjectSuggestionRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-project-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/new-project-suggestions/{id}"
+    }
+  }
+}

--- a/cms/src/api/new-project-suggestion/routes/new-project-suggestion.ts
+++ b/cms/src/api/new-project-suggestion/routes/new-project-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-project-suggestion router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::new-project-suggestion.new-project-suggestion');

--- a/cms/src/api/new-project-suggestion/services/new-project-suggestion.ts
+++ b/cms/src/api/new-project-suggestion/services/new-project-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-project-suggestion service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::new-project-suggestion.new-project-suggestion');

--- a/cms/src/api/new-tool-suggestion/content-types/new-tool-suggestion/schema.json
+++ b/cms/src/api/new-tool-suggestion/content-types/new-tool-suggestion/schema.json
@@ -1,0 +1,41 @@
+{
+  "kind": "collectionType",
+  "collectionName": "new_tool_suggestions",
+  "info": {
+    "singularName": "new-tool-suggestion",
+    "pluralName": "new-tool-suggestions",
+    "displayName": "New Tool Suggestion"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "string"
+    },
+    "link": {
+      "type": "string",
+      "required": true
+    },
+    "other_tools_category": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::other-tools-category.other-tools-category"
+    },
+    "review_status": {
+      "type": "enumeration",
+      "enum": [
+        "pending",
+        "approved",
+        "declined"
+      ],
+      "required": true,
+      "default": "pending"
+    }
+  }
+}

--- a/cms/src/api/new-tool-suggestion/controllers/new-tool-suggestion.ts
+++ b/cms/src/api/new-tool-suggestion/controllers/new-tool-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-tool-suggestion controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::new-tool-suggestion.new-tool-suggestion');

--- a/cms/src/api/new-tool-suggestion/documentation/1.0.0/new-tool-suggestion.json
+++ b/cms/src/api/new-tool-suggestion/documentation/1.0.0/new-tool-suggestion.json
@@ -1,0 +1,507 @@
+{
+  "/new-tool-suggestions": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewToolSuggestionListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-tool-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/new-tool-suggestions"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewToolSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-tool-suggestion"
+      ],
+      "parameters": [],
+      "operationId": "post/new-tool-suggestions",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/NewToolSuggestionRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/new-tool-suggestions/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewToolSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-tool-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/new-tool-suggestions/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewToolSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-tool-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/new-tool-suggestions/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/NewToolSuggestionRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "New-tool-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/new-tool-suggestions/{id}"
+    }
+  }
+}

--- a/cms/src/api/new-tool-suggestion/routes/new-tool-suggestion.ts
+++ b/cms/src/api/new-tool-suggestion/routes/new-tool-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-tool-suggestion router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::new-tool-suggestion.new-tool-suggestion');

--- a/cms/src/api/new-tool-suggestion/services/new-tool-suggestion.ts
+++ b/cms/src/api/new-tool-suggestion/services/new-tool-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * new-tool-suggestion service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::new-tool-suggestion.new-tool-suggestion');

--- a/cms/src/api/other-tool/content-types/other-tool/schema.json
+++ b/cms/src/api/other-tool/content-types/other-tool/schema.json
@@ -28,6 +28,12 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::other-tools-category.other-tools-category"
+    },
+    "tool_edit_suggestions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::tool-edit-suggestion.tool-edit-suggestion",
+      "mappedBy": "other_tool"
     }
   }
 }

--- a/cms/src/api/pillar/content-types/pillar/schema.json
+++ b/cms/src/api/pillar/content-types/pillar/schema.json
@@ -26,6 +26,18 @@
     "description": {
       "type": "richtext",
       "required": true
+    },
+    "new_project_suggestions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::new-project-suggestion.new-project-suggestion",
+      "mappedBy": "pillar"
+    },
+    "project_edit_suggestions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::project-edit-suggestion.project-edit-suggestion",
+      "mappedBy": "pillar"
     }
   }
 }

--- a/cms/src/api/project-edit-suggestion/content-types/project-edit-suggestion/schema.json
+++ b/cms/src/api/project-edit-suggestion/content-types/project-edit-suggestion/schema.json
@@ -1,10 +1,10 @@
 {
   "kind": "collectionType",
-  "collectionName": "projects",
+  "collectionName": "project_edit_suggestions",
   "info": {
-    "singularName": "project",
-    "pluralName": "projects",
-    "displayName": "Project",
+    "singularName": "project-edit-suggestion",
+    "pluralName": "project-edit-suggestions",
+    "displayName": "Project Edit Suggestion",
     "description": ""
   },
   "options": {
@@ -14,7 +14,7 @@
   "attributes": {
     "name": {
       "type": "string",
-      "required": true
+      "required": false
     },
     "countries": {
       "type": "relation",
@@ -25,7 +25,7 @@
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::pillar.pillar",
-      "inversedBy": "projects"
+      "inversedBy": "project_edit_suggestions"
     },
     "highlight": {
       "type": "richtext"
@@ -40,7 +40,7 @@
       "type": "relation",
       "relation": "manyToMany",
       "target": "api::sdg.sdg",
-      "inversedBy": "projects"
+      "inversedBy": "project_edit_suggestions"
     },
     "status": {
       "type": "string"
@@ -60,11 +60,21 @@
     "info": {
       "type": "string"
     },
-    "project_edit_suggestions": {
+    "review_status": {
+      "type": "enumeration",
+      "enum": [
+        "pending",
+        "approved",
+        "declined"
+      ],
+      "default": "pending",
+      "required": true
+    },
+    "project": {
       "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::project-edit-suggestion.project-edit-suggestion",
-      "mappedBy": "project"
+      "relation": "manyToOne",
+      "target": "api::project.project",
+      "inversedBy": "project_edit_suggestions"
     }
   }
 }

--- a/cms/src/api/project-edit-suggestion/controllers/project-edit-suggestion.ts
+++ b/cms/src/api/project-edit-suggestion/controllers/project-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * project-edit-suggestion controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::project-edit-suggestion.project-edit-suggestion');

--- a/cms/src/api/project-edit-suggestion/documentation/1.0.0/project-edit-suggestion.json
+++ b/cms/src/api/project-edit-suggestion/documentation/1.0.0/project-edit-suggestion.json
@@ -1,0 +1,507 @@
+{
+  "/project-edit-suggestions": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectEditSuggestionListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Project-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/project-edit-suggestions"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Project-edit-suggestion"
+      ],
+      "parameters": [],
+      "operationId": "post/project-edit-suggestions",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProjectEditSuggestionRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/project-edit-suggestions/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Project-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/project-edit-suggestions/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Project-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/project-edit-suggestions/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProjectEditSuggestionRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Project-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/project-edit-suggestions/{id}"
+    }
+  }
+}

--- a/cms/src/api/project-edit-suggestion/routes/project-edit-suggestion.ts
+++ b/cms/src/api/project-edit-suggestion/routes/project-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * project-edit-suggestion router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::project-edit-suggestion.project-edit-suggestion');

--- a/cms/src/api/project-edit-suggestion/services/project-edit-suggestion.ts
+++ b/cms/src/api/project-edit-suggestion/services/project-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * project-edit-suggestion service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::project-edit-suggestion.project-edit-suggestion');

--- a/cms/src/api/sdg/content-types/sdg/schema.json
+++ b/cms/src/api/sdg/content-types/sdg/schema.json
@@ -21,6 +21,18 @@
       "relation": "manyToMany",
       "target": "api::project.project",
       "mappedBy": "sdgs"
+    },
+    "new_project_suggestions": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::new-project-suggestion.new-project-suggestion",
+      "mappedBy": "sdgs"
+    },
+    "project_edit_suggestions": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::project-edit-suggestion.project-edit-suggestion",
+      "mappedBy": "sdgs"
     }
   }
 }

--- a/cms/src/api/tool-edit-suggestion/content-types/tool-edit-suggestion/schema.json
+++ b/cms/src/api/tool-edit-suggestion/content-types/tool-edit-suggestion/schema.json
@@ -1,0 +1,46 @@
+{
+  "kind": "collectionType",
+  "collectionName": "tool_edit_suggestions",
+  "info": {
+    "singularName": "tool-edit-suggestion",
+    "pluralName": "tool-edit-suggestions",
+    "displayName": "Tool Edit Suggestion",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "link": {
+      "type": "string"
+    },
+    "other_tools_category": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::other-tools-category.other-tools-category"
+    },
+    "other_tool": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::other-tool.other-tool",
+      "inversedBy": "tool_edit_suggestions"
+    },
+    "review_status": {
+      "type": "enumeration",
+      "enum": [
+        "pending",
+        "approved",
+        "declined"
+      ],
+      "default": "pending",
+      "required": true
+    }
+  }
+}

--- a/cms/src/api/tool-edit-suggestion/controllers/tool-edit-suggestion.ts
+++ b/cms/src/api/tool-edit-suggestion/controllers/tool-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * tool-edit-suggestion controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::tool-edit-suggestion.tool-edit-suggestion');

--- a/cms/src/api/tool-edit-suggestion/documentation/1.0.0/tool-edit-suggestion.json
+++ b/cms/src/api/tool-edit-suggestion/documentation/1.0.0/tool-edit-suggestion.json
@@ -1,0 +1,507 @@
+{
+  "/tool-edit-suggestions": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToolEditSuggestionListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Tool-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/tool-edit-suggestions"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToolEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Tool-edit-suggestion"
+      ],
+      "parameters": [],
+      "operationId": "post/tool-edit-suggestions",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ToolEditSuggestionRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/tool-edit-suggestions/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToolEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Tool-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/tool-edit-suggestions/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToolEditSuggestionResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Tool-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/tool-edit-suggestions/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ToolEditSuggestionRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Tool-edit-suggestion"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/tool-edit-suggestions/{id}"
+    }
+  }
+}

--- a/cms/src/api/tool-edit-suggestion/routes/tool-edit-suggestion.ts
+++ b/cms/src/api/tool-edit-suggestion/routes/tool-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * tool-edit-suggestion router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::tool-edit-suggestion.tool-edit-suggestion');

--- a/cms/src/api/tool-edit-suggestion/services/tool-edit-suggestion.ts
+++ b/cms/src/api/tool-edit-suggestion/services/tool-edit-suggestion.ts
@@ -1,0 +1,7 @@
+/**
+ * tool-edit-suggestion service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::tool-edit-suggestion.tool-edit-suggestion');

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -695,6 +695,16 @@ export interface ApiCategoryCategory extends Schema.CollectionType {
       'oneToMany',
       'api::dataset.dataset'
     >;
+    new_dataset_suggestions: Attribute.Relation<
+      'api::category.category',
+      'oneToMany',
+      'api::new-dataset-suggestion.new-dataset-suggestion'
+    >;
+    dataset_edit_suggestions: Attribute.Relation<
+      'api::category.category',
+      'oneToMany',
+      'api::dataset-edit-suggestion.dataset-edit-suggestion'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -728,6 +738,11 @@ export interface ApiCollaboratorCollaborator extends Schema.CollectionType {
     name: Attribute.String & Attribute.Required;
     link: Attribute.String;
     type: Attribute.Enumeration<['donor', 'collaborator']> & Attribute.Required;
+    collaborator_edit_suggestions: Attribute.Relation<
+      'api::collaborator.collaborator',
+      'oneToMany',
+      'api::collaborator-edit-suggestion.collaborator-edit-suggestion'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -739,6 +754,47 @@ export interface ApiCollaboratorCollaborator extends Schema.CollectionType {
       Attribute.Private;
     updatedBy: Attribute.Relation<
       'api::collaborator.collaborator',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiCollaboratorEditSuggestionCollaboratorEditSuggestion
+  extends Schema.CollectionType {
+  collectionName: 'collaborator_edit_suggestions';
+  info: {
+    singularName: 'collaborator-edit-suggestion';
+    pluralName: 'collaborator-edit-suggestions';
+    displayName: 'Collaborator Edit Suggestion';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    link: Attribute.String;
+    type: Attribute.Enumeration<['donor', 'collaborator']>;
+    collaborator: Attribute.Relation<
+      'api::collaborator-edit-suggestion.collaborator-edit-suggestion',
+      'manyToOne',
+      'api::collaborator.collaborator'
+    >;
+    review_status: Attribute.Enumeration<['pending', 'approved', 'declined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'pending'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::collaborator-edit-suggestion.collaborator-edit-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::collaborator-edit-suggestion.collaborator-edit-suggestion',
       'oneToOne',
       'admin::user'
     > &
@@ -811,6 +867,11 @@ export interface ApiDatasetDataset extends Schema.CollectionType {
       ['text', 'number', 'boolean', 'resource']
     > &
       Attribute.Required;
+    dataset_edit_suggestions: Attribute.Relation<
+      'api::dataset.dataset',
+      'oneToMany',
+      'api::dataset-edit-suggestion.dataset-edit-suggestion'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -822,6 +883,62 @@ export interface ApiDatasetDataset extends Schema.CollectionType {
       Attribute.Private;
     updatedBy: Attribute.Relation<
       'api::dataset.dataset',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiDatasetEditSuggestionDatasetEditSuggestion
+  extends Schema.CollectionType {
+  collectionName: 'dataset_edit_suggestions';
+  info: {
+    singularName: 'dataset-edit-suggestion';
+    pluralName: 'dataset-edit-suggestions';
+    displayName: 'Dataset Edit Suggestion';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    datum: Attribute.JSON;
+    category: Attribute.Relation<
+      'api::dataset-edit-suggestion.dataset-edit-suggestion',
+      'manyToOne',
+      'api::category.category'
+    >;
+    description: Attribute.RichText;
+    layers: Attribute.Relation<
+      'api::dataset-edit-suggestion.dataset-edit-suggestion',
+      'oneToMany',
+      'api::layer.layer'
+    >;
+    unit: Attribute.String;
+    value_type: Attribute.Enumeration<
+      ['text', 'number', 'boolean', 'resource']
+    >;
+    review_status: Attribute.Enumeration<['pending', 'approved', 'declined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'pending'>;
+    dataset: Attribute.Relation<
+      'api::dataset-edit-suggestion.dataset-edit-suggestion',
+      'manyToOne',
+      'api::dataset.dataset'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::dataset-edit-suggestion.dataset-edit-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::dataset-edit-suggestion.dataset-edit-suggestion',
       'oneToOne',
       'admin::user'
     > &
@@ -938,6 +1055,16 @@ export interface ApiLayerLayer extends Schema.CollectionType {
       'manyToOne',
       'api::dataset.dataset'
     >;
+    new_dataset_suggestion: Attribute.Relation<
+      'api::layer.layer',
+      'manyToOne',
+      'api::new-dataset-suggestion.new-dataset-suggestion'
+    >;
+    dataset_edit_suggestion: Attribute.Relation<
+      'api::layer.layer',
+      'manyToOne',
+      'api::dataset-edit-suggestion.dataset-edit-suggestion'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -949,6 +1076,194 @@ export interface ApiLayerLayer extends Schema.CollectionType {
       Attribute.Private;
     updatedBy: Attribute.Relation<
       'api::layer.layer',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiNewCollaboratorSuggestionNewCollaboratorSuggestion
+  extends Schema.CollectionType {
+  collectionName: 'new_collaborator_suggestions';
+  info: {
+    singularName: 'new-collaborator-suggestion';
+    pluralName: 'new-collaborator-suggestions';
+    displayName: 'New Collaborator Suggestion';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    link: Attribute.String;
+    type: Attribute.Enumeration<['donor', 'collaborator']> & Attribute.Required;
+    review_status: Attribute.Enumeration<['pending', 'approved', 'declined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'pending'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::new-collaborator-suggestion.new-collaborator-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::new-collaborator-suggestion.new-collaborator-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiNewDatasetSuggestionNewDatasetSuggestion
+  extends Schema.CollectionType {
+  collectionName: 'new_dataset_suggestions';
+  info: {
+    singularName: 'new-dataset-suggestion';
+    pluralName: 'new-dataset-suggestions';
+    displayName: 'New Dataset Suggestion';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    datum: Attribute.JSON & Attribute.Required;
+    category: Attribute.Relation<
+      'api::new-dataset-suggestion.new-dataset-suggestion',
+      'manyToOne',
+      'api::category.category'
+    >;
+    description: Attribute.RichText & Attribute.Required;
+    layers: Attribute.Relation<
+      'api::new-dataset-suggestion.new-dataset-suggestion',
+      'oneToMany',
+      'api::layer.layer'
+    >;
+    unit: Attribute.String;
+    value_type: Attribute.Enumeration<
+      ['text', 'number', 'boolean', 'resource']
+    > &
+      Attribute.Required;
+    review_status: Attribute.Enumeration<['pending', 'approved', 'declined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'pending'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::new-dataset-suggestion.new-dataset-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::new-dataset-suggestion.new-dataset-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiNewProjectSuggestionNewProjectSuggestion
+  extends Schema.CollectionType {
+  collectionName: 'new_project_suggestions';
+  info: {
+    singularName: 'new-project-suggestion';
+    pluralName: 'new-project-suggestions';
+    displayName: 'New Project Suggestion';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    countries: Attribute.Relation<
+      'api::new-project-suggestion.new-project-suggestion',
+      'oneToMany',
+      'api::country.country'
+    >;
+    pillar: Attribute.Relation<
+      'api::new-project-suggestion.new-project-suggestion',
+      'manyToOne',
+      'api::pillar.pillar'
+    >;
+    highlight: Attribute.RichText;
+    account: Attribute.String;
+    amount: Attribute.Float;
+    sdgs: Attribute.Relation<
+      'api::new-project-suggestion.new-project-suggestion',
+      'manyToMany',
+      'api::sdg.sdg'
+    >;
+    status: Attribute.String;
+    funding: Attribute.String;
+    source_country: Attribute.String;
+    organization_type: Attribute.String;
+    objective: Attribute.Text;
+    info: Attribute.String;
+    review_status: Attribute.Enumeration<['pending', 'approved', 'declined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'pending'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::new-project-suggestion.new-project-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::new-project-suggestion.new-project-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiNewToolSuggestionNewToolSuggestion
+  extends Schema.CollectionType {
+  collectionName: 'new_tool_suggestions';
+  info: {
+    singularName: 'new-tool-suggestion';
+    pluralName: 'new-tool-suggestions';
+    displayName: 'New Tool Suggestion';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    description: Attribute.String;
+    link: Attribute.String & Attribute.Required;
+    other_tools_category: Attribute.Relation<
+      'api::new-tool-suggestion.new-tool-suggestion',
+      'oneToOne',
+      'api::other-tools-category.other-tools-category'
+    >;
+    review_status: Attribute.Enumeration<['pending', 'approved', 'declined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'pending'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::new-tool-suggestion.new-tool-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::new-tool-suggestion.new-tool-suggestion',
       'oneToOne',
       'admin::user'
     > &
@@ -975,6 +1290,11 @@ export interface ApiOtherToolOtherTool extends Schema.CollectionType {
       'api::other-tool.other-tool',
       'oneToOne',
       'api::other-tools-category.other-tools-category'
+    >;
+    tool_edit_suggestions: Attribute.Relation<
+      'api::other-tool.other-tool',
+      'oneToMany',
+      'api::tool-edit-suggestion.tool-edit-suggestion'
     >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
@@ -1044,6 +1364,16 @@ export interface ApiPillarPillar extends Schema.CollectionType {
       'api::project.project'
     >;
     description: Attribute.RichText & Attribute.Required;
+    new_project_suggestions: Attribute.Relation<
+      'api::pillar.pillar',
+      'oneToMany',
+      'api::new-project-suggestion.new-project-suggestion'
+    >;
+    project_edit_suggestions: Attribute.Relation<
+      'api::pillar.pillar',
+      'oneToMany',
+      'api::project-edit-suggestion.project-edit-suggestion'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -1095,6 +1425,15 @@ export interface ApiProjectProject extends Schema.CollectionType {
     >;
     status: Attribute.String;
     funding: Attribute.String;
+    source_country: Attribute.String;
+    organization_type: Attribute.String;
+    objective: Attribute.Text;
+    info: Attribute.String;
+    project_edit_suggestions: Attribute.Relation<
+      'api::project.project',
+      'oneToMany',
+      'api::project-edit-suggestion.project-edit-suggestion'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -1106,6 +1445,70 @@ export interface ApiProjectProject extends Schema.CollectionType {
       Attribute.Private;
     updatedBy: Attribute.Relation<
       'api::project.project',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiProjectEditSuggestionProjectEditSuggestion
+  extends Schema.CollectionType {
+  collectionName: 'project_edit_suggestions';
+  info: {
+    singularName: 'project-edit-suggestion';
+    pluralName: 'project-edit-suggestions';
+    displayName: 'Project Edit Suggestion';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    countries: Attribute.Relation<
+      'api::project-edit-suggestion.project-edit-suggestion',
+      'oneToMany',
+      'api::country.country'
+    >;
+    pillar: Attribute.Relation<
+      'api::project-edit-suggestion.project-edit-suggestion',
+      'manyToOne',
+      'api::pillar.pillar'
+    >;
+    highlight: Attribute.RichText;
+    account: Attribute.String;
+    amount: Attribute.Float;
+    sdgs: Attribute.Relation<
+      'api::project-edit-suggestion.project-edit-suggestion',
+      'manyToMany',
+      'api::sdg.sdg'
+    >;
+    status: Attribute.String;
+    funding: Attribute.String;
+    source_country: Attribute.String;
+    organization_type: Attribute.String;
+    objective: Attribute.Text;
+    info: Attribute.String;
+    review_status: Attribute.Enumeration<['pending', 'approved', 'declined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'pending'>;
+    project: Attribute.Relation<
+      'api::project-edit-suggestion.project-edit-suggestion',
+      'manyToOne',
+      'api::project.project'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::project-edit-suggestion.project-edit-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::project-edit-suggestion.project-edit-suggestion',
       'oneToOne',
       'admin::user'
     > &
@@ -1163,12 +1566,69 @@ export interface ApiSdgSdg extends Schema.CollectionType {
       'manyToMany',
       'api::project.project'
     >;
+    new_project_suggestions: Attribute.Relation<
+      'api::sdg.sdg',
+      'manyToMany',
+      'api::new-project-suggestion.new-project-suggestion'
+    >;
+    project_edit_suggestions: Attribute.Relation<
+      'api::sdg.sdg',
+      'manyToMany',
+      'api::project-edit-suggestion.project-edit-suggestion'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<'api::sdg.sdg', 'oneToOne', 'admin::user'> &
       Attribute.Private;
     updatedBy: Attribute.Relation<'api::sdg.sdg', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface ApiToolEditSuggestionToolEditSuggestion
+  extends Schema.CollectionType {
+  collectionName: 'tool_edit_suggestions';
+  info: {
+    singularName: 'tool-edit-suggestion';
+    pluralName: 'tool-edit-suggestions';
+    displayName: 'Tool Edit Suggestion';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    description: Attribute.String;
+    link: Attribute.String;
+    other_tools_category: Attribute.Relation<
+      'api::tool-edit-suggestion.tool-edit-suggestion',
+      'oneToOne',
+      'api::other-tools-category.other-tools-category'
+    >;
+    other_tool: Attribute.Relation<
+      'api::tool-edit-suggestion.tool-edit-suggestion',
+      'manyToOne',
+      'api::other-tool.other-tool'
+    >;
+    review_status: Attribute.Enumeration<['pending', 'approved', 'declined']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'pending'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::tool-edit-suggestion.tool-edit-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::tool-edit-suggestion.tool-edit-suggestion',
+      'oneToOne',
+      'admin::user'
+    > &
       Attribute.Private;
   };
 }
@@ -1191,17 +1651,25 @@ declare module '@strapi/types' {
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'api::category.category': ApiCategoryCategory;
       'api::collaborator.collaborator': ApiCollaboratorCollaborator;
+      'api::collaborator-edit-suggestion.collaborator-edit-suggestion': ApiCollaboratorEditSuggestionCollaboratorEditSuggestion;
       'api::country.country': ApiCountryCountry;
       'api::dataset.dataset': ApiDatasetDataset;
+      'api::dataset-edit-suggestion.dataset-edit-suggestion': ApiDatasetEditSuggestionDatasetEditSuggestion;
       'api::dataset-value.dataset-value': ApiDatasetValueDatasetValue;
       'api::download-email.download-email': ApiDownloadEmailDownloadEmail;
       'api::layer.layer': ApiLayerLayer;
+      'api::new-collaborator-suggestion.new-collaborator-suggestion': ApiNewCollaboratorSuggestionNewCollaboratorSuggestion;
+      'api::new-dataset-suggestion.new-dataset-suggestion': ApiNewDatasetSuggestionNewDatasetSuggestion;
+      'api::new-project-suggestion.new-project-suggestion': ApiNewProjectSuggestionNewProjectSuggestion;
+      'api::new-tool-suggestion.new-tool-suggestion': ApiNewToolSuggestionNewToolSuggestion;
       'api::other-tool.other-tool': ApiOtherToolOtherTool;
       'api::other-tools-category.other-tools-category': ApiOtherToolsCategoryOtherToolsCategory;
       'api::pillar.pillar': ApiPillarPillar;
       'api::project.project': ApiProjectProject;
+      'api::project-edit-suggestion.project-edit-suggestion': ApiProjectEditSuggestionProjectEditSuggestion;
       'api::resource.resource': ApiResourceResource;
       'api::sdg.sdg': ApiSdgSdg;
+      'api::tool-edit-suggestion.tool-edit-suggestion': ApiToolEditSuggestionToolEditSuggestion;
     }
   }
 }


### PR DESCRIPTION
This PR adds new Collection Types to store the suggestions of Edits or New creations for Projects, Collaborators and Datasets:
- New Project Suggestion - all fields from Project + review_status (Enum: pending, approved, declined; required field,; default: pending)
- Project Edit Suggestion - all fields from Project + review_status (Enum: pending, approved, declined; required field; default: pending) + relation with Project to be changed
- New Collaborator Suggestion - all fields from Collaborator + review_status (Enum: pending, approved, declined; required field; default: pending)
- Collaborator Edit Suggestion - all fields from Collaborator + review_status (Enum: pending, approved, declined; required field; default: pending) + relation with Collaborator to be changed
- New Dataset Suggestion - all fields from Dataset + review_status (Enum: pending, approved, declined; required field; default: pending)
- Dataset Edit Suggestion - all fields from Dataset + review_status (Enum: pending, approved, declined; required field,;default: pending) + relation with Dataset to be changed
- New Tool Suggestion - all fields from Other Tool + review_status (Enum: pending, approved, declined; required field; default: pending)
- Tool Edit Suggestion - all fields from Other Tool + review_status (Enum: pending, approved, declined; required field; default: pending) + relation with Other Tool to be changed