### PR TITLE
regex added to datasets

### DIFF
--- a/client/src/containers/collaborators/form/index.tsx
+++ b/client/src/containers/collaborators/form/index.tsx
@@ -191,13 +191,14 @@ export default function CollaboratorForm() {
       .refine((val) => !!val, {
         message: "Please select a relation type",
       }),
-    link: z.string().refine(
-      (value) => {
-        // This regex requires the URL to start with either http://, https://, or www.
-        return /^(https?:\/\/|www\.)[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(\/[^\s]*)?$/.test(value);
-      },
-      { message: "Please enter a valid URL" },
-    ),
+    link: z
+      .string()
+      .regex(
+        new RegExp(
+          "^(https?:\\/\\/)?(www\\.)?[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+(\\/[a-zA-Z0-9-]*)*$",
+        ),
+        { message: "Please enter a valid URL" },
+      ),
     image: z.number().min(1, { message: "Please ass image" }),
   });
 


### PR DESCRIPTION
This pull request includes an update to the URL validation logic in the `CollaboratorForm` component to simplify and improve the regex pattern used.

Changes to URL validation:

* [`client/src/containers/collaborators/form/index.tsx`](diffhunk://#diff-52315988b779add364677713abc5eee05185cf00e6bf094763273d7833b043a1L194-R199): Updated the `link` field validation to use a more concise regex pattern for URL validation, ensuring it starts with either `http://`, `https://`, or `www.` and includes a valid domain and optional path.