### PR TITLE
other funding type

### DIFF
--- a/client/src/containers/projects/popup.tsx
+++ b/client/src/containers/projects/popup.tsx
@@ -81,6 +81,7 @@ const ProjectPopup = () => {
   const countries = data?.data?.attributes?.countries;
   const projectStatus = data?.data?.attributes?.status?.data?.attributes?.name;
   const projectTypeOfFunding = data?.data?.attributes?.funding?.data?.attributes?.name;
+  const projectOtherFunding = data?.data?.attributes?.other_funding;
   const organizationType = data?.data?.attributes?.organization_type?.data?.attributes?.name;
   const sourceCountry = data?.data?.attributes?.source_country?.data?.attributes?.name;
   const objective = data?.data?.attributes?.objective?.data?.attributes?.type;
@@ -226,7 +227,12 @@ const ProjectPopup = () => {
                 title="Type of funding"
                 data={dataInfo?.data?.attributes?.funding}
               />
-              <div className="text-sm">{projectTypeOfFunding}</div>
+              <div className="text-sm">
+                {projectTypeOfFunding}
+                {projectTypeOfFunding === "Other" &&
+                  projectOtherFunding &&
+                  `: (${projectOtherFunding})`}
+              </div>
             </div>
           )}
         </section>

--- a/client/src/types/generated/strapi.schemas.ts
+++ b/client/src/types/generated/strapi.schemas.ts
@@ -3209,6 +3209,7 @@ export type SdgProjectsDataItemAttributes = {
   name?: string;
   objective?: SdgProjectsDataItemAttributesObjective;
   organization_type?: SdgProjectsDataItemAttributesOrganizationType;
+  other_funding?: string;
   pillar?: SdgProjectsDataItemAttributesPillar;
   project_edit_suggestions?: SdgProjectsDataItemAttributesProjectEditSuggestions;
   publishedAt?: string;
@@ -5697,6 +5698,7 @@ export type ProjectEditSuggestionPillarDataAttributesProjectsDataItemAttributes 
   name?: string;
   objective?: ProjectEditSuggestionPillarDataAttributesProjectsDataItemAttributesObjective;
   organization_type?: ProjectEditSuggestionPillarDataAttributesProjectsDataItemAttributesOrganizationType;
+  other_funding?: string;
   pillar?: ProjectEditSuggestionPillarDataAttributesProjectsDataItemAttributesPillar;
   project_edit_suggestions?: ProjectEditSuggestionPillarDataAttributesProjectsDataItemAttributesProjectEditSuggestions;
   publishedAt?: string;
@@ -7361,6 +7363,7 @@ export interface Project {
   name: string;
   objective?: ProjectObjective;
   organization_type?: ProjectOrganizationType;
+  other_funding?: string;
   pillar?: ProjectPillar;
   project_edit_suggestions?: ProjectProjectEditSuggestions;
   publishedAt?: string;
@@ -7475,6 +7478,7 @@ export type ProjectPillarDataAttributesProjectsDataItemAttributes = {
   name?: string;
   objective?: ProjectPillarDataAttributesProjectsDataItemAttributesObjective;
   organization_type?: ProjectPillarDataAttributesProjectsDataItemAttributesOrganizationType;
+  other_funding?: string;
   pillar?: ProjectPillarDataAttributesProjectsDataItemAttributesPillar;
   project_edit_suggestions?: ProjectPillarDataAttributesProjectsDataItemAttributesProjectEditSuggestions;
   publishedAt?: string;
@@ -9094,6 +9098,7 @@ export type ProjectRequestData = {
   name: string;
   objective?: ProjectRequestDataObjective;
   organization_type?: ProjectRequestDataOrganizationType;
+  other_funding?: string;
   pillar?: ProjectRequestDataPillar;
   project_edit_suggestions?: ProjectRequestDataProjectEditSuggestionsItem[];
   sdgs?: ProjectRequestDataSdgsItem[];
@@ -9172,6 +9177,7 @@ export type PillarProjectsDataItemAttributes = {
   name?: string;
   objective?: PillarProjectsDataItemAttributesObjective;
   organization_type?: PillarProjectsDataItemAttributesOrganizationType;
+  other_funding?: string;
   pillar?: PillarProjectsDataItemAttributesPillar;
   project_edit_suggestions?: PillarProjectsDataItemAttributesProjectEditSuggestions;
   publishedAt?: string;

--- a/cms/src/api/project/content-types/project/schema.json
+++ b/cms/src/api/project/content-types/project/schema.json
@@ -75,6 +75,9 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::project-status.project-status"
+    },
+    "other_funding": {
+      "type": "string"
     }
   }
 }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -1343,6 +1343,7 @@ export interface ApiProjectProject extends Schema.CollectionType {
       'oneToOne',
       'api::project-status.project-status'
     >;
+    other_funding: Attribute.String;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
This pull request introduces support for specifying an "Other" type of funding for projects, including validation, form handling, and display logic. The changes ensure that when "Other" is selected as the funding type, users are prompted to provide additional details, and these details are shown in the project popup.

### Form validation and handling

* Added a new `other_funding` field to the project form schema and implemented custom validation to require this field when "Other" funding is selected. [[1]](diffhunk://#diff-b7b3abb8fa529d3b1a1538e1766448db4f276992b88b540d88b769ae79624726L305-R308) [[2]](diffhunk://#diff-b7b3abb8fa529d3b1a1538e1766448db4f276992b88b540d88b769ae79624726R334-R350)
* Used `useWatch` to dynamically monitor the selected funding type and conditionally render the `other_funding` input field in the form. [[1]](diffhunk://#diff-b7b3abb8fa529d3b1a1538e1766448db4f276992b88b540d88b769ae79624726R377) [[2]](diffhunk://#diff-b7b3abb8fa529d3b1a1538e1766448db4f276992b88b540d88b769ae79624726R864-R894)

### Project popup display

* Updated the project popup to display the `other_funding` value alongside the funding type when "Other" is selected, improving user visibility of custom funding descriptions. [[1]](diffhunk://#diff-31de1e1859a652b660a4b446b5376abccee5afa80918713f1a5470018a62c434R57) [[2]](diffhunk://#diff-31de1e1859a652b660a4b446b5376abccee5afa80918713f1a5470018a62c434L194-R200)

### Backend schema update

* Added the `other_funding` string field to the project schema in the CMS to persist this new data.