### PR TITLE
dockerfile prod runner

### DIFF
--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -35,7 +35,7 @@ RUN yarn install
 RUN yarn build
 
 # Copy only the built files into the final image
-FROM node:22-bookworm-slim AS build
+FROM node:22-bookworm-slim AS runner
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 

--- a/client/src/components/ui/video.tsx
+++ b/client/src/components/ui/video.tsx
@@ -17,6 +17,7 @@ export function Video({ src, type = "video/mp4", classname, height, width }: Vid
     isYouTube = hostname === "youtube.com" || hostname === "youtu.be";
 
     if (isYouTube) {
+      // v parameter for regular YouTube links
       if (hostname === "youtube.com" && url.searchParams.has("v")) {
         embedSrc = `https://youtube.com/embed/${url.searchParams.get("v")}`;
       } else if (hostname === "youtu.be") {

--- a/cms/Dockerfile.prod
+++ b/cms/Dockerfile.prod
@@ -37,7 +37,7 @@ RUN yarn install
 RUN yarn build
 
 # Copy only the built files into the final image
-node:22.20.0-bookworm-slim AS build
+node:22.20.0-bookworm-slim AS runner
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y libvips-dev && \


### PR DESCRIPTION
This pull request includes minor updates to Docker configuration and a small code comment improvement. The main changes involve renaming Docker build stages for consistency and clarifying the YouTube embed logic in the video component.

**Dockerfile improvements:**

* Renamed the build stage from `build` to `runner` in both `client/Dockerfile.prod` and `cms/Dockerfile.prod` to improve clarity and consistency in naming. [[1]](diffhunk://#diff-4207b82ce3e2d93a66107f6209ff16cba83d8a00ab64a55ce663d98e10c8f231L38-R38) [[2]](diffhunk://#diff-f5efd24d3b832660895e3ae390f4c263201703c8e086b22121784af7c189b416L40-R40)

**Code clarity:**

* Added a comment in the `Video` component (`client/src/components/ui/video.tsx`) to clarify the handling of the `v` parameter for regular YouTube links.