### PR TITLE
icon hidden when no info

### DIFF
--- a/client/src/containers/projects/popup.tsx
+++ b/client/src/containers/projects/popup.tsx
@@ -27,18 +27,20 @@ import { ProjectsStatusProgressBar } from "./status-progress-bar";
 const ProjectFieldHeader = ({ title, data }: { title: string; data: string | undefined }) => (
   <div className="flex items-center">
     <h3 className="text-xxs uppercase text-gray-500">{title}</h3>
-    <Tooltip>
-      <TooltipTrigger>
-        <LuInfo className="h-4 w-4 pl-1 font-bold text-gray-500" />
-      </TooltipTrigger>
+    {data && (
+      <Tooltip>
+        <TooltipTrigger>
+          <LuInfo className="h-4 w-4 pl-1 font-bold text-gray-500" />
+        </TooltipTrigger>
 
-      <TooltipPortal>
-        <TooltipContent side="right" align="center">
-          <Markdown className="prose text-xxs">{data}</Markdown>
-          <TooltipArrow className="fill-white" width={10} height={5} />
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+        <TooltipPortal>
+          <TooltipContent side="right" align="center">
+            <Markdown className="prose text-xxs">{data}</Markdown>
+            <TooltipArrow className="fill-white" width={10} height={5} />
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    )}
   </div>
 );
 


### PR DESCRIPTION
This pull request makes a small update to the `ProjectFieldHeader` component in the `client/src/containers/projects/popup.tsx` file. It ensures that the tooltip icon and its associated tooltip are only rendered when the `data` prop is present, preventing unnecessary UI elements from appearing when there is no data to display. [[1]](diffhunk://#diff-31de1e1859a652b660a4b446b5376abccee5afa80918713f1a5470018a62c434R30) [[2]](diffhunk://#diff-31de1e1859a652b660a4b446b5376abccee5afa80918713f1a5470018a62c434R43)