### PR TITLE
fix: year_established display bug and type mismatch in project entities

### DIFF
--- a/client/src/containers/projects/popup.tsx
+++ b/client/src/containers/projects/popup.tsx
@@ -121,7 +121,7 @@ const ProjectPopup = () => {
           {/* STATUS  - progress bar*/}
           <ProjectsStatusProgressBar {...projectStatus} />
           {/* STATUS  - year established*/}
-          {!yearEstablished && (
+          {yearEstablished && (
             <div className="space-y-3.5">
               <div className="flex items-center space-x-1">
                 <span className="text-xxs font-semibold uppercase tracking-wide text-gray-500">

--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -847,6 +847,7 @@
           "highlight",
           "account",
           "amount",
+          "year_established",
           "funding",
           "objective",
           "info",
@@ -860,7 +861,8 @@
           "reviewed_by",
           "source_country",
           "organization_type",
-          "status"
+          "status",
+          "video_link"
         ]
       },
       "conditions": []
@@ -889,6 +891,7 @@
           "highlight",
           "account",
           "amount",
+          "year_established",
           "funding",
           "objective",
           "info",
@@ -902,7 +905,8 @@
           "reviewed_by",
           "source_country",
           "organization_type",
-          "status"
+          "status",
+          "video_link"
         ]
       },
       "conditions": []
@@ -917,6 +921,7 @@
           "highlight",
           "account",
           "amount",
+          "year_established",
           "funding",
           "objective",
           "info",
@@ -930,7 +935,103 @@
           "reviewed_by",
           "source_country",
           "organization_type",
-          "status"
+          "status",
+          "video_link"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::project-field-metadata.project-field-metadata",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "objective",
+          "info",
+          "funding",
+          "organization_type",
+          "source_country",
+          "status",
+          "description",
+          "video_link",
+          "other_funding",
+          "year_established"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::project-field-metadata.project-field-metadata",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::project-field-metadata.project-field-metadata",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::project-field-metadata.project-field-metadata",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "objective",
+          "info",
+          "funding",
+          "organization_type",
+          "source_country",
+          "status",
+          "description",
+          "video_link",
+          "other_funding",
+          "year_established"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::project-field-metadata.project-field-metadata",
+      "properties": {
+        "fields": [
+          "name",
+          "countries",
+          "pillar",
+          "highlight",
+          "account",
+          "amount",
+          "sdgs",
+          "objective",
+          "info",
+          "funding",
+          "organization_type",
+          "source_country",
+          "status",
+          "description",
+          "video_link",
+          "other_funding",
+          "year_established"
         ]
       },
       "conditions": []
@@ -941,7 +1042,8 @@
       "subject": "api::project-status.project-status",
       "properties": {
         "fields": [
-          "name"
+          "name",
+          "maturity"
         ]
       },
       "conditions": []
@@ -966,7 +1068,8 @@
       "subject": "api::project-status.project-status",
       "properties": {
         "fields": [
-          "name"
+          "name",
+          "maturity"
         ]
       },
       "conditions": []
@@ -977,7 +1080,8 @@
       "subject": "api::project-status.project-status",
       "properties": {
         "fields": [
-          "name"
+          "name",
+          "maturity"
         ]
       },
       "conditions": []
@@ -1001,7 +1105,10 @@
           "funding",
           "organization_type",
           "source_country",
-          "status"
+          "status",
+          "other_funding",
+          "video_link",
+          "year_established"
         ]
       },
       "conditions": []
@@ -1039,7 +1146,10 @@
           "funding",
           "organization_type",
           "source_country",
-          "status"
+          "status",
+          "other_funding",
+          "video_link",
+          "year_established"
         ]
       },
       "conditions": []
@@ -1063,7 +1173,10 @@
           "funding",
           "organization_type",
           "source_country",
-          "status"
+          "status",
+          "other_funding",
+          "video_link",
+          "year_established"
         ]
       },
       "conditions": []

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project-field-metadata.project-field-metadata.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project-field-metadata.project-field-metadata.json
@@ -1,14 +1,14 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::project-edit-suggestion.project-edit-suggestion",
+  "key": "plugin_content_manager_configuration_content_types::api::project-field-metadata.project-field-metadata",
   "value": {
-    "uid": "api::project-edit-suggestion.project-edit-suggestion",
+    "uid": "api::project-field-metadata.project-field-metadata",
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
       "pageSize": 10,
-      "mainField": "name",
-      "defaultSortBy": "name",
+      "mainField": "id",
+      "defaultSortBy": "id",
       "defaultSortOrder": "ASC"
     },
     "metadatas": {
@@ -30,8 +30,36 @@
         },
         "list": {
           "label": "name",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "countries": {
+        "edit": {
+          "label": "countries",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "countries",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "pillar": {
+        "edit": {
+          "label": "pillar",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "pillar",
+          "searchable": false,
+          "sortable": false
         }
       },
       "highlight": {
@@ -58,8 +86,8 @@
         },
         "list": {
           "label": "account",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "amount": {
@@ -72,37 +100,22 @@
         },
         "list": {
           "label": "amount",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
-      "year_established": {
+      "sdgs": {
         "edit": {
-          "label": "year_established",
+          "label": "sdgs",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "year_established",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "funding": {
-        "edit": {
-          "label": "funding",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "funding",
-          "searchable": true,
-          "sortable": true
+          "label": "sdgs",
+          "searchable": false,
+          "sortable": false
         }
       },
       "objective": {
@@ -111,13 +124,12 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "type"
+          "editable": true
         },
         "list": {
           "label": "objective",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "info": {
@@ -130,140 +142,22 @@
         },
         "list": {
           "label": "info",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "review_status": {
-        "edit": {
-          "label": "review_status",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "review_status",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "author": {
-        "edit": {
-          "label": "author",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "username"
-        },
-        "list": {
-          "label": "author",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "countries": {
-        "edit": {
-          "label": "countries",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "countries",
           "searchable": false,
           "sortable": false
         }
       },
-      "pillar": {
+      "funding": {
         "edit": {
-          "label": "pillar",
+          "label": "funding",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "name"
+          "editable": true
         },
         "list": {
-          "label": "pillar",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "sdgs": {
-        "edit": {
-          "label": "sdgs",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "sdgs",
+          "label": "funding",
           "searchable": false,
           "sortable": false
-        }
-      },
-      "project": {
-        "edit": {
-          "label": "project",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "name"
-        },
-        "list": {
-          "label": "project",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "review_decision_details": {
-        "edit": {
-          "label": "review_decision_details",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "review_decision_details",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "reviewed_by": {
-        "edit": {
-          "label": "reviewed_by",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "reviewed_by",
-          "searchable": true,
-          "sortable": true
-        }
-      },
-      "source_country": {
-        "edit": {
-          "label": "source_country",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "code"
-        },
-        "list": {
-          "label": "source_country",
-          "searchable": true,
-          "sortable": true
         }
       },
       "organization_type": {
@@ -272,13 +166,26 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "name"
+          "editable": true
         },
         "list": {
           "label": "organization_type",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "source_country": {
+        "edit": {
+          "label": "source_country",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "source_country",
+          "searchable": false,
+          "sortable": false
         }
       },
       "status": {
@@ -287,13 +194,26 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "name"
+          "editable": true
         },
         "list": {
           "label": "status",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "description": {
+        "edit": {
+          "label": "description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": false,
+          "sortable": false
         }
       },
       "video_link": {
@@ -306,8 +226,36 @@
         },
         "list": {
           "label": "video_link",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "other_funding": {
+        "edit": {
+          "label": "other_funding",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "other_funding",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "year_established": {
+        "edit": {
+          "label": "year_established",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "year_established",
+          "searchable": false,
+          "sortable": false
         }
       },
       "createdAt": {
@@ -372,15 +320,27 @@
     "layouts": {
       "list": [
         "id",
-        "name",
-        "account",
-        "amount"
+        "createdAt",
+        "updatedAt",
+        "createdBy"
       ],
       "edit": [
         [
           {
             "name": "name",
-            "size": 6
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "countries",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "pillar",
+            "size": 12
           }
         ],
         [
@@ -392,93 +352,79 @@
         [
           {
             "name": "account",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "amount",
-            "size": 4
+            "size": 12
           }
         ],
         [
           {
-            "name": "year_established",
-            "size": 4
-          }
-        ],
-        [
-          {
-            "name": "status",
-            "size": 6
-          },
-          {
-            "name": "funding",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "source_country",
-            "size": 6
-          },
-          {
-            "name": "organization_type",
-            "size": 6
+            "name": "sdgs",
+            "size": 12
           }
         ],
         [
           {
             "name": "objective",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "info",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
-            "name": "review_status",
-            "size": 6
+            "name": "funding",
+            "size": 12
           }
         ],
         [
           {
-            "name": "author",
-            "size": 6
-          },
-          {
-            "name": "countries",
-            "size": 6
+            "name": "organization_type",
+            "size": 12
           }
         ],
         [
           {
-            "name": "pillar",
-            "size": 6
-          },
-          {
-            "name": "sdgs",
-            "size": 6
+            "name": "source_country",
+            "size": 12
           }
         ],
         [
           {
-            "name": "project",
-            "size": 6
-          },
-          {
-            "name": "review_decision_details",
-            "size": 6
+            "name": "status",
+            "size": 12
           }
         ],
         [
           {
-            "name": "reviewed_by",
-            "size": 6
-          },
+            "name": "description",
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "video_link",
-            "size": 6
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "other_funding",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "year_established",
+            "size": 12
           }
         ]
       ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project-status.project-status.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project-status.project-status.json
@@ -34,6 +34,20 @@
           "sortable": true
         }
       },
+      "maturity": {
+        "edit": {
+          "label": "maturity",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "maturity",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -105,6 +119,10 @@
           {
             "name": "name",
             "size": 6
+          },
+          {
+            "name": "maturity",
+            "size": 4
           }
         ]
       ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
@@ -225,6 +225,48 @@
           "sortable": true
         }
       },
+      "other_funding": {
+        "edit": {
+          "label": "other_funding",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "other_funding",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "video_link": {
+        "edit": {
+          "label": "video_link",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "video_link",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "year_established": {
+        "edit": {
+          "label": "year_established",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "year_established",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -314,6 +356,10 @@
           {
             "name": "amount",
             "size": 4
+          },
+          {
+            "name": "year_established",
+            "size": 4
           }
         ],
         [
@@ -367,6 +413,16 @@
         [
           {
             "name": "funding",
+            "size": 6
+          },
+          {
+            "name": "other_funding",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "video_link",
             "size": 6
           }
         ]

--- a/cms/src/api/project-edit-suggestion/content-types/project-edit-suggestion/schema.json
+++ b/cms/src/api/project-edit-suggestion/content-types/project-edit-suggestion/schema.json
@@ -26,7 +26,7 @@
       "type": "float"
     },
     "year_established": {
-      "type": "float"
+      "type": "integer"
     },
     "funding": {
       "type": "relation",


### PR DESCRIPTION
Fix inverted condition in popup showing year_established only when empty. Change year_established type from float to integer in project-edit-suggestion schema. Add year_established to config-sync metadata and edit layouts for both project and project-edit-suggestion content types.