### PR TITLE
maturity sorting

### DIFF
--- a/client/src/containers/projects/form/index.tsx
+++ b/client/src/containers/projects/form/index.tsx
@@ -76,7 +76,7 @@ const ProjectFieldLabel = ({
   required = false,
 }: {
   title: string;
-  data: string | number | undefined;
+  data: string | undefined;
   required?: boolean;
 }) => (
   <FormLabel className="flex items-center text-xs font-semibold">
@@ -860,7 +860,7 @@ export default function ProjectForm() {
                   <FormItem className="space-y-1.5">
                     <ProjectFieldLabel
                       title="Year established"
-                      data={dataInfo?.data?.attributes?.year_established}
+                      data={dataInfo?.data?.attributes?.year_established?.toString()}
                       required
                     />
                     <FormControl>

--- a/client/src/containers/projects/form/index.tsx
+++ b/client/src/containers/projects/form/index.tsx
@@ -76,7 +76,7 @@ const ProjectFieldLabel = ({
   required = false,
 }: {
   title: string;
-  data: string | undefined;
+  data: string | number | undefined;
   required?: boolean;
 }) => (
   <FormLabel className="flex items-center text-xs font-semibold">

--- a/client/src/containers/projects/form/index.tsx
+++ b/client/src/containers/projects/form/index.tsx
@@ -188,7 +188,7 @@ export default function ProjectForm() {
   const { data: organizationTypes } = useGetOrganizationTypes(
     {
       "pagination[pageSize]": 100,
-      sort: "maturity:asc",
+      sort: "name:asc",
     },
     {
       query: {

--- a/client/src/types/generated/strapi.schemas.ts
+++ b/client/src/types/generated/strapi.schemas.ts
@@ -3361,6 +3361,7 @@ export type SdgProjectsDataItemAttributesPillarDataAttributesProjectEditSuggesti
     updatedAt?: string;
     updatedBy?: SdgProjectsDataItemAttributesPillarDataAttributesProjectEditSuggestionsDataItemAttributesUpdatedBy;
     video_link?: string;
+    year_established?: number;
   };
 
 export type SdgProjectsDataItemAttributesPillarDataAttributesProjectEditSuggestionsDataItem = {
@@ -5347,7 +5348,7 @@ export interface ProjectFieldMetadata {
   updatedAt?: string;
   updatedBy?: ProjectFieldMetadataUpdatedBy;
   video_link?: string;
-  year_established?: string;
+  year_established?: number;
 }
 
 export type ProjectFieldMetadataCreatedByDataAttributesUpdatedByDataAttributes = {
@@ -5554,6 +5555,7 @@ export type ProjectFieldMetadataRequestData = {
   source_country?: string;
   status?: string;
   video_link?: string;
+  year_established?: number;
 };
 
 export interface ProjectFieldMetadataRequest {
@@ -5683,6 +5685,7 @@ export interface ProjectEditSuggestion {
   updatedAt?: string;
   updatedBy?: ProjectEditSuggestionUpdatedBy;
   video_link?: string;
+  year_established?: number;
 }
 
 export type ProjectEditSuggestionPillarDataAttributesUpdatedByDataAttributes = {
@@ -5857,6 +5860,7 @@ export type ProjectEditSuggestionPillarDataAttributesProjectsDataItemAttributesS
     updatedAt?: string;
     updatedBy?: ProjectEditSuggestionPillarDataAttributesProjectsDataItemAttributesSdgsDataItemAttributesProjectEditSuggestionsDataItemAttributesUpdatedBy;
     video_link?: string;
+    year_established?: number;
   };
 
 export type ProjectEditSuggestionPillarDataAttributesProjectsDataItemAttributesSdgsDataItemAttributesProjectEditSuggestionsDataItem =
@@ -7359,6 +7363,7 @@ export type ProjectEditSuggestionRequestData = {
   source_country?: ProjectEditSuggestionRequestDataSourceCountry;
   status?: ProjectEditSuggestionRequestDataStatus;
   video_link?: string;
+  year_established?: number;
 };
 
 export type ProjectResponseMeta = { [key: string]: any };
@@ -7655,6 +7660,7 @@ export type ProjectPillarDataAttributesProjectsDataItemAttributesSdgsDataItemAtt
     updatedAt?: string;
     updatedBy?: ProjectPillarDataAttributesProjectsDataItemAttributesSdgsDataItemAttributesProjectEditSuggestionsDataItemAttributesUpdatedBy;
     video_link?: string;
+    year_established?: number;
   };
 
 export type ProjectPillarDataAttributesProjectsDataItemAttributesSdgsDataItemAttributesProjectEditSuggestionsDataItem =
@@ -9353,6 +9359,7 @@ export type PillarProjectsDataItemAttributesPillarDataAttributesProjectEditSugge
     updatedAt?: string;
     updatedBy?: PillarProjectsDataItemAttributesPillarDataAttributesProjectEditSuggestionsDataItemAttributesUpdatedBy;
     video_link?: string;
+    year_established?: number;
   };
 
 export type PillarProjectsDataItemAttributesPillarDataAttributesProjectEditSuggestionsDataItemAttributesStatusDataAttributes =


### PR DESCRIPTION
This pull request makes a minor update to the sorting logic for organization types in the `ProjectForm` component. The change improves the user experience by sorting organization types alphabetically by name instead of by maturity.

* Changed the sort parameter from `maturity:asc` to `name:asc` in the `useGetOrganizationTypes` hook within `client/src/containers/projects/form/index.tsx`.