### PR TITLE
rename import columns

### DIFF
--- a/client/src/containers/projects/form/index.tsx
+++ b/client/src/containers/projects/form/index.tsx
@@ -625,7 +625,7 @@ export default function ProjectForm() {
               countries: "",
               source_country: "",
               sdgs: "",
-              pillars: "",
+              sectors: "",
               organization_type: "",
               info: "", // If no info, keep it as an empty string
               funding: "", // If no funding, keep it as an empty string

--- a/cms/src/api/project/services/project.ts
+++ b/cms/src/api/project/services/project.ts
@@ -220,11 +220,12 @@ export default factories.createCoreService("api::project.project", {
         );
         const publishedAt = new Date().toISOString();
 
+        const { sector, ...rowWithoutSector } = row;
         const updatedRow: any = {
-          ...row,
+          ...rowWithoutSector,
           countries: countryIds,
           sdgs: sdgIds,
-          sector: pillarIds,
+          pillar: pillarIds,
           status,
           source_country: sourceCountry,
           objective,

--- a/cms/src/api/project/services/project.ts
+++ b/cms/src/api/project/services/project.ts
@@ -2,10 +2,10 @@
  * project service
  */
 
-import {factories} from '@strapi/strapi';
-import * as fs from 'fs';
-import * as csv from 'csv-parse/sync';
-import * as stringify from 'csv-stringify/sync';
+import { factories } from "@strapi/strapi";
+import * as fs from "fs";
+import * as csv from "csv-parse/sync";
+import * as stringify from "csv-stringify/sync";
 
 interface ProjectRow {
   countries: string;
@@ -15,10 +15,13 @@ interface ProjectRow {
 }
 
 async function findProjectStatusIdByName(name: string): Promise<number> {
-  const result: any = await strapi.entityService.findMany('api::project-status.project-status', {
-    filters: { name },
-    fields: ['id'],
-  });
+  const result: any = await strapi.entityService.findMany(
+    "api::project-status.project-status",
+    {
+      filters: { name },
+      fields: ["id"],
+    }
+  );
 
   if (result.length === 0) {
     throw new Error(`No project status found with the name "${name}"`);
@@ -28,10 +31,13 @@ async function findProjectStatusIdByName(name: string): Promise<number> {
 }
 
 async function findObjectiveIdByType(type: string): Promise<number> {
-  const result: any = await strapi.entityService.findMany('api::objective.objective', {
-    filters: { type },
-    fields: ['id'],
-  });
+  const result: any = await strapi.entityService.findMany(
+    "api::objective.objective",
+    {
+      filters: { type },
+      fields: ["id"],
+    }
+  );
 
   if (result.length === 0) {
     throw new Error(`No objective found with the name "${type}"`);
@@ -41,10 +47,13 @@ async function findObjectiveIdByType(type: string): Promise<number> {
 }
 
 async function findOrganizationTypeIdByName(name: string): Promise<number> {
-  const result: any = await strapi.entityService.findMany('api::organization-type.organization-type', {
-    filters: { name },
-    fields: ['id'],
-  });
+  const result: any = await strapi.entityService.findMany(
+    "api::organization-type.organization-type",
+    {
+      filters: { name },
+      fields: ["id"],
+    }
+  );
 
   if (result.length === 0) {
     throw new Error(`No organization type found with the name "${name}"`);
@@ -54,10 +63,13 @@ async function findOrganizationTypeIdByName(name: string): Promise<number> {
 }
 
 async function findFundingIdByName(name: string): Promise<number> {
-  const result: any = await strapi.entityService.findMany('api::organization-type.organization-type', {
-    filters: { name },
-    fields: ['id'],
-  });
+  const result: any = await strapi.entityService.findMany(
+    "api::organization-type.organization-type",
+    {
+      filters: { name },
+      fields: ["id"],
+    }
+  );
 
   if (result.length === 0) {
     throw new Error(`No funding found with the name "${name}"`);
@@ -67,10 +79,13 @@ async function findFundingIdByName(name: string): Promise<number> {
 }
 
 async function findWorldCountryIdByName(name: string): Promise<number> {
-  const result: any = await strapi.entityService.findMany('api::world-country.world-country', {
-    filters: { name },
-    fields: ['id'],
-  });
+  const result: any = await strapi.entityService.findMany(
+    "api::world-country.world-country",
+    {
+      filters: { name },
+      fields: ["id"],
+    }
+  );
 
   if (result.length === 0) {
     throw new Error(`No world country found with the name "${name}"`);
@@ -79,13 +94,14 @@ async function findWorldCountryIdByName(name: string): Promise<number> {
   return result[0].id;
 }
 
-
-
 async function findCountryIdByName(name: string): Promise<number> {
-  const result: any = await strapi.entityService.findMany('api::country.country', {
-    filters: { name },
-    fields: ['id'],
-  });
+  const result: any = await strapi.entityService.findMany(
+    "api::country.country",
+    {
+      filters: { name },
+      fields: ["id"],
+    }
+  );
 
   if (result.length === 0) {
     throw new Error(`No country found with the name "${name}"`);
@@ -95,9 +111,9 @@ async function findCountryIdByName(name: string): Promise<number> {
 }
 
 async function findSdgIdByName(name: string): Promise<number> {
-  const result: any = await strapi.entityService.findMany('api::sdg.sdg', {
+  const result: any = await strapi.entityService.findMany("api::sdg.sdg", {
     filters: { name },
-    fields: ['id'],
+    fields: ["id"],
   });
 
   if (result.length === 0) {
@@ -108,10 +124,13 @@ async function findSdgIdByName(name: string): Promise<number> {
 }
 
 async function findPillarIdByName(name: string): Promise<number> {
-  const result: any = await strapi.entityService.findMany('api::pillar.pillar', {
-    filters: { name },
-    fields: ['id'],
-  });
+  const result: any = await strapi.entityService.findMany(
+    "api::pillar.pillar",
+    {
+      filters: { name },
+      fields: ["id"],
+    }
+  );
 
   if (result.length === 0) {
     throw new Error(`No pillar found with the name "${name}"`);
@@ -120,12 +139,25 @@ async function findPillarIdByName(name: string): Promise<number> {
   return result[0].id;
 }
 
-export default factories.createCoreService('api::project.project', {
+export default factories.createCoreService("api::project.project", {
   async parseAndReplaceIds(file, author = null) {
     // Read and parse the CSV file
-    const fileContent = fs.readFileSync(file.path, 'utf8');
+    const fileContent = fs.readFileSync(file.path, "utf8");
 
-    const allowedColumns = ['name', 'highlight', 'status', 'objective', 'amount', 'countries', 'source_country', 'sdgs', 'pillar', 'organization_type', 'info', 'funding'];
+    const allowedColumns = [
+      "name",
+      "highlight",
+      "status",
+      "objective",
+      "amount",
+      "countries",
+      "source_country",
+      "sdgs",
+      "sector",
+      "organization_type",
+      "info",
+      "funding",
+    ];
 
     const records: ProjectRow[] = csv.parse(fileContent, {
       columns: true,
@@ -133,57 +165,82 @@ export default factories.createCoreService('api::project.project', {
     });
 
     if (records.length === 0) {
-      throw new Error('CSV file is empty');
+      throw new Error("CSV file is empty");
     }
 
     const csvColumns = Object.keys(records[0]);
 
-    const invalidColumns = csvColumns.filter(col => !allowedColumns.includes(col));
+    const invalidColumns = csvColumns.filter(
+      (col) => !allowedColumns.includes(col)
+    );
     if (invalidColumns.length > 0) {
-      throw new Error(`Invalid columns detected: ${invalidColumns.join(', ')}`);
+      throw new Error(`Invalid columns detected: ${invalidColumns.join(", ")}`);
     }
 
-    const missingColumns = allowedColumns.filter(col => !csvColumns.includes(col));
+    const missingColumns = allowedColumns.filter(
+      (col) => !csvColumns.includes(col)
+    );
+
     if (missingColumns.length > 0) {
-      throw new Error(`Missing required columns: ${missingColumns.join(', ')}`);
+      throw new Error(`Missing required columns: ${missingColumns.join(", ")}`);
     }
 
     // Process each row
-    const updatedRecords = await Promise.all(records.map(async (row: ProjectRow) => {
-      const countryNames = row.countries.split(';').map(name => name.trim());
-      const sdgNames = row.sdgs.split(';').map(name => name.trim());
-      const pillarNames = row.pillar.split(';').map(name => name.trim());
-      const status = row.status ? [await findProjectStatusIdByName(row.status)] : [];
-      const sourceCountry = row.source_country ? [await findWorldCountryIdByName(row.source_country)] : [];
-      const objective = row.objective ? [await findObjectiveIdByType(row.objective)] : [];
-      const organizationType = row.organization_type ? [await findOrganizationTypeIdByName(row.organization_type)] : []
-      const funding = row.funding ? [await findFundingIdByName(row.funding)]: [];
+    const updatedRecords = await Promise.all(
+      records.map(async (row: ProjectRow) => {
+        const countryNames = row.countries
+          .split(";")
+          .map((name) => name.trim());
+        const sdgNames = row.sdgs.split(";").map((name) => name.trim());
+        const pillarNames = row.sector.split(";").map((name) => name.trim());
+        const status = row.status
+          ? [await findProjectStatusIdByName(row.status)]
+          : [];
+        const sourceCountry = row.source_country
+          ? [await findWorldCountryIdByName(row.source_country)]
+          : [];
+        const objective = row.objective
+          ? [await findObjectiveIdByType(row.objective)]
+          : [];
+        const organizationType = row.organization_type
+          ? [await findOrganizationTypeIdByName(row.organization_type)]
+          : [];
+        const funding = row.funding
+          ? [await findFundingIdByName(row.funding)]
+          : [];
 
-      const countryIds = await Promise.all(countryNames.map(name => findCountryIdByName(name)));
-      const sdgIds = await Promise.all(sdgNames.map(name => findSdgIdByName(name)));
-      const pillarIds = await Promise.all(pillarNames.map(name => findPillarIdByName(name)));
-      const publishedAt = new Date().toISOString();
+        const countryIds = await Promise.all(
+          countryNames.map((name) => findCountryIdByName(name))
+        );
+        const sdgIds = await Promise.all(
+          sdgNames.map((name) => findSdgIdByName(name))
+        );
+        const pillarIds = await Promise.all(
+          pillarNames.map((name) => findPillarIdByName(name))
+        );
+        const publishedAt = new Date().toISOString();
 
-      const updatedRow: any = {
-        ...row,
-        countries: countryIds,
-        sdgs: sdgIds,
-        pillar: pillarIds,
-        status,
-        source_country: sourceCountry,
-        objective,
-        organization_type: organizationType,
-        funding,
-        publishedAt,
-      };
+        const updatedRow: any = {
+          ...row,
+          countries: countryIds,
+          sdgs: sdgIds,
+          sector: pillarIds,
+          status,
+          source_country: sourceCountry,
+          objective,
+          organization_type: organizationType,
+          funding,
+          publishedAt,
+        };
 
-      // Add author relation if provided
-      if (author) {
-        updatedRow.author = [author];
-      }
+        // Add author relation if provided
+        if (author) {
+          updatedRow.author = [author];
+        }
 
-      return updatedRow;
-    }));
+        return updatedRow;
+      })
+    );
 
     const updatedCSV = stringify.stringify(updatedRecords, { header: true });
 


### PR DESCRIPTION
This pull request updates the handling of project "pillars" and "sectors" in both the frontend and backend, standardizing on the term "sector" and ensuring consistency in CSV import/export and form handling. It also refactors the code for better readability and maintainability, particularly around string formatting and column validation.

**Backend changes (CSV import and project service):**

* Replaced all references to "pillar" with "sector" in CSV import logic, including allowed columns and row processing. Now, the `sector` field is used for mapping to pillar IDs, and the output field is also named `sector` instead of `pillar`.
* Improved code formatting and readability by standardizing on double quotes, adding whitespace, and using more readable function argument formatting throughout the service. [[1]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L5-R8) [[2]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L18-R24) [[3]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L31-R40) [[4]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L44-R56) [[5]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L57-R72) [[6]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L70-R88) [[7]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L82-R104) [[8]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L98-R116) [[9]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L111-R133) [[10]](diffhunk://#diff-56975bfde9c1a5174d7842d2861672b9ce6ed1dc8a760eab471c4dd00e597376L186-R243)
* Enhanced CSV column validation by improving error messages and splitting logic for missing and invalid columns for clarity.

**Frontend changes (project form):**

* Updated the project form initial state to use `sectors` instead of `pillars`, aligning the frontend with the backend changes.