### PR TITLE
fix(deps): address 2 dependency vulnerabilities

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -68,7 +68,7 @@
     "pino": "8.15.1",
     "pino-http": "8.5.0",
     "pino-pretty": "10.2.0",
-    "postcss": "8.4.30",
+    "postcss": "8.5.10",
     "react": "18.2.0",
     "react-cookie": "^7.1.4",
     "react-dom": "18.2.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6694,7 +6694,7 @@ __metadata:
     pino: 8.15.1
     pino-http: 8.5.0
     pino-pretty: 10.2.0
-    postcss: 8.4.30
+    postcss: 8.5.10
     prettier: 3.0.3
     prettier-plugin-tailwindcss: 0.5.4
     react: 18.2.0
@@ -12105,6 +12105,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.11":
+  version: 3.3.12
+  resolution: "nanoid@npm:3.3.12"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 38699257447dc59e21e73e0510d0dfb16b7a610d9ca80633d5c3a68f9b4298c990513d30404ca8f163c2d03225ee01695ff8898bea6179183f38f0477b7635ac
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.6":
   version: 3.3.6
   resolution: "nanoid@npm:3.3.6"
@@ -12929,6 +12938,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
@@ -13156,17 +13172,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.30":
-  version: 8.4.30
-  resolution: "postcss@npm:8.4.30"
-  dependencies:
-    nanoid: ^3.3.6
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: 6c810c10c9bd3e03ca016e0b6b6756261e640aba1a9a7b1200b55502bc34b9165e38f590aef3493afc2f30ab55cdfcd43fd0f8408d69a77318ddbcf2a8ad164b
-  languageName: node
-  linkType: hard
-
 "postcss@npm:8.4.31, postcss@npm:^8.4.23":
   version: 8.4.31
   resolution: "postcss@npm:8.4.31"
@@ -13175,6 +13180,17 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: 1d8611341b073143ad90486fcdfeab49edd243377b1f51834dc4f6d028e82ce5190e4f11bb2633276864503654fb7cab28e67abdc0fbf9d1f88cad4a0ff0beea
+  languageName: node
+  linkType: hard
+
+"postcss@npm:8.5.10":
+  version: 8.5.10
+  resolution: "postcss@npm:8.5.10"
+  dependencies:
+    nanoid: ^3.3.11
+    picocolors: ^1.1.1
+    source-map-js: ^1.2.1
+  checksum: 9af9cd7f2f0d4b8456f6710e48d586328433509b695911fda942c24ac4db4e62c6fed8c6c6d8c8258326285f669494c2c36a4ff84aa160f0586eb545e5258bf5
   languageName: node
   linkType: hard
 
@@ -14873,6 +14889,13 @@ __metadata:
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: c049a7fc4deb9a7e9b481ae3d424cc793cb4845daa690bc5a05d428bf41bf231ced49b4cf0c9e77f9d42fdb3d20d6187619fc586605f5eabe995a316da8d377c
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 4eb0cd997cdf228bc253bcaff9340afeb706176e64868ecd20efbe6efea931465f43955612346d6b7318789e5265bdc419bc7669c1cebe3db0eb255f57efa76b
   languageName: node
   linkType: hard
 

--- a/cms/package.json
+++ b/cms/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@strapi/plugin-documentation": "^4.15.0",
     "@strapi/plugin-i18n": "4.15.0",
-    "@strapi/plugin-users-permissions": "4.15.0",
+    "@strapi/plugin-users-permissions": "4.25.4",
     "@strapi/provider-email-amazon-ses": "4.15.0",
     "@strapi/provider-upload-aws-s3": "4.15.0",
     "@strapi/provider-upload-local": "4.15.0",

--- a/cms/yarn.lock
+++ b/cms/yarn.lock
@@ -2819,6 +2819,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@strapi/helper-plugin@npm:4.25.4":
+  version: 4.25.4
+  resolution: "@strapi/helper-plugin@npm:4.25.4"
+  dependencies:
+    axios: 1.6.0
+    date-fns: 2.30.0
+    formik: 2.4.0
+    immer: 9.0.19
+    lodash: 4.17.21
+    qs: 6.11.1
+    react-helmet: 6.1.0
+    react-intl: 6.4.1
+    react-query: 3.39.3
+    react-select: 5.7.0
+  peerDependencies:
+    "@strapi/design-system": 1.19.0
+    "@strapi/icons": 1.19.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
+  checksum: 83bd024641448e8da91c61596cc840075cd59a7d394ecdba72549c272ec401ba5b935908f1eb8069bf05798a0277f6eecac6d24eeb6c60750b3547e1ca0cf3f3
+  languageName: node
+  linkType: hard
+
 "@strapi/helper-plugin@npm:4.26.0":
   version: 4.26.0
   resolution: "@strapi/helper-plugin@npm:4.26.0"
@@ -3081,14 +3106,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/plugin-users-permissions@npm:4.15.0":
-  version: 4.15.0
-  resolution: "@strapi/plugin-users-permissions@npm:4.15.0"
+"@strapi/plugin-users-permissions@npm:4.25.4":
+  version: 4.25.4
+  resolution: "@strapi/plugin-users-permissions@npm:4.25.4"
   dependencies:
-    "@strapi/design-system": 1.13.0
-    "@strapi/helper-plugin": 4.15.0
-    "@strapi/icons": 1.13.0
-    "@strapi/utils": 4.15.0
+    "@strapi/design-system": 1.19.0
+    "@strapi/helper-plugin": 4.25.4
+    "@strapi/icons": 1.19.0
+    "@strapi/utils": 4.25.4
     bcryptjs: 2.4.3
     formik: 2.4.0
     grant-koa: 5.4.8
@@ -3106,11 +3131,12 @@ __metadata:
     url-join: 4.0.1
     yup: 0.32.9
   peerDependencies:
+    "@strapi/strapi": ^4.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
-  checksum: 8e2b089f13be63194d52d685fd0f3e05bb4d3d4bc3c527b02f3085151ad0c5f0f03cb1f5fb3389c9224249890636f035e27bc23fdecc1e9f1e20c93045933d7d
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
+  checksum: 4a2af10f04e65f1ad675fff36f874aa93beae45ae1d78243bf21b1ca4831f495b38ce62298249ae04946e079767188a05f7448573305727e0e2b7ba9b1e47cc0
   languageName: node
   linkType: hard
 
@@ -3309,6 +3335,20 @@ __metadata:
     p-map: 4.0.0
     yup: 0.32.9
   checksum: a1234c7aa4b49d650ba740890958778699a4e48dc603fe7e3b742547955a2e407e8c49fbec329d95ca3ea792cf5a18754dbf3ab1eb48bc491fbc6c1e1ae11425
+  languageName: node
+  linkType: hard
+
+"@strapi/utils@npm:4.25.4":
+  version: 4.25.4
+  resolution: "@strapi/utils@npm:4.25.4"
+  dependencies:
+    "@sindresorhus/slugify": 1.1.0
+    date-fns: 2.30.0
+    http-errors: 1.8.1
+    lodash: 4.17.21
+    p-map: 4.0.0
+    yup: 0.32.9
+  checksum: 7a24645f57cd788a9e2089cae086b2dfecd45e6408c22252984ed04fd6490bb65aaad61cd9791eeddc23413f39cc1723872e7703f197a0bf182e788d7dfe43d6
   languageName: node
   linkType: hard
 
@@ -4626,6 +4666,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:1.6.0":
+  version: 1.6.0
+  resolution: "axios@npm:1.6.0"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: c7c9f2ae9e0b9bad7d6f9a4dff030930b12ee667dedf54c3c776714f91681feb743c509ac0796ae5c01e12c4ab4a2bee74905068dd200fbc1ab86f9814578fb0
+  languageName: node
+  linkType: hard
+
 "axios@npm:1.8.2":
   version: 1.8.2
   resolution: "axios@npm:1.8.2"
@@ -5250,7 +5301,7 @@ __metadata:
   dependencies:
     "@strapi/plugin-documentation": ^4.15.0
     "@strapi/plugin-i18n": 4.15.0
-    "@strapi/plugin-users-permissions": 4.15.0
+    "@strapi/plugin-users-permissions": 4.25.4
     "@strapi/provider-email-amazon-ses": 4.15.0
     "@strapi/provider-upload-aws-s3": 4.15.0
     "@strapi/provider-upload-local": 4.15.0


### PR DESCRIPTION
## Summary

Direct-dependency audit of both yarn workspaces (`client`, `cms`) on 2026-05-13. Two vulnerabilities fixed via direct upgrades (Strategy A, exact pinned versions). One major-version upgrade deferred.

| Pkg | Workspace | Sev | From → To | Advisory |
|-----|-----------|-----|-----------|----------|
| postcss | client | moderate | 8.4.30 → 8.5.10 | [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — XSS via unescaped `</style>` |
| @strapi/plugin-users-permissions | cms | high | 4.15.0 → 4.25.4 | [GHSA-wrvh-rcmr-9qfc](https://github.com/advisories/GHSA-wrvh-rcmr-9qfc) — auth bypass / 3rd-party token leak |

### Deferred

- `@strapi/strapi 4.15.0` — [GHSA-4r8w-3jww-m2rp](https://github.com/advisories/GHSA-4r8w-3jww-m2rp) (moderate, insufficient session expiration). Patched only in `>=5.24.1`. No 4.x patch exists. Requires Strapi 4 → 5 migration (breaking changes across lifecycle hooks, content/plugin APIs, DB layer). Out of scope for this `fix(deps):` session — track separately.

### Audit scope caveat

`yarn npm audit --recursive` returns `YN0035: 400 Bad Request` against the registry bulk-audit endpoint, so transitive-dep coverage is limited to what direct audits surfaced. GitHub Dependabot reports 199 advisories on `main` (mostly transitive); those should be triaged in a follow-up session, ideally after the Strapi 4 → 5 migration since Strapi 4 pins many vulnerable transitives.

## Test plan

- [x] `yarn npm audit --all` clean in `client`
- [x] `yarn npm audit --all` in `cms` shows only deferred Strapi advisory
- [x] `yarn build` succeeds in `client` (Next.js 16.2.6 / Turbopack)
- [x] `yarn build` succeeds in `cms` (Strapi admin webpack build)
- [ ] CI: Client E2E workflow green (note: separate Playwright CDN issue may still block)
- [ ] Manual smoke: `yarn dev` (client) + `yarn develop` (cms) boot without runtime errors