### PR TITLE
fix(docker): chown /app so strapi user can write at runtime

### DIFF
--- a/cms/Dockerfile.prod
+++ b/cms/Dockerfile.prod
@@ -16,6 +16,12 @@ ENV NODE_ENV production
 
 WORKDIR /app
 
+# Set HOME so corepack writes its cache into /app/.cache instead of /root/.cache.
+# This way the cache is included in the COPY --from=build that follows in the runner stage,
+# and yarn never needs to download itself at container startup.
+ENV HOME=/app
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
 COPY .yarn ./.yarn
 COPY config ./config
 COPY database ./database
@@ -32,7 +38,7 @@ COPY .env \
      yarn.lock \
      ./
 
-RUN corepack enable
+RUN corepack enable && corepack prepare yarn@3.6.4 --activate
 
 RUN yarn install
 
@@ -52,13 +58,18 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 --home /app strapi
 ENV HOME=/app
-#Need to explicitly set a HOME folder because the entrypoint script uses yarn, and the packageManager will force to use
-#corepack to install yarn, but its cache folder is written in the HOME folder
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+# HOME=/app makes corepack derive its cache path as /app/.cache/node/corepack/.
+# Combined with the build stage pre-populating that cache, yarn starts offline.
 
 COPY --from=build --chown=strapi:nodejs /app ./
 
-ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable
+
+# WORKDIR /app creates the directory as root:root mode 0755, and COPY --chown only
+# chowns the copied *contents*, not /app itself. Without this, the strapi user can
+# traverse /app but cannot create new entries in it (e.g. /app/.cache on first yarn run).
+RUN chown strapi:nodejs /app
 
 USER strapi
 

--- a/cms/package.json
+++ b/cms/package.json
@@ -36,7 +36,7 @@
   },
   "packageManager": "yarn@3.6.4",
   "engines": {
-    "node": ">=16.0.0 <=20.x.x",
+    "node": ">=16.0.0 <=22.x.x",
     "npm": ">=6.0.0"
   },
   "strapi": {


### PR DESCRIPTION
## Summary

Fixes the staging ELB outage where the CMS container exited at startup with `Error: EACCES: permission denied, mkdir '/app/.cache/node/corepack/v1'`, which in turn caused nginx 502s on `/cms/api/*` and an ELB health-check failure / restart loop.

- **Root cause:** `WORKDIR /app` creates the dir as `root:root` mode `0755`. `COPY --chown=strapi:nodejs /app ./` only chowns the *copied contents*, not `/app` itself. `adduser --home /app` doesn't chown an existing dir either. The `strapi` user could traverse `/app` but couldn't create new entries in it (like `.cache/`), so the first `yarn` invocation crashed.
- **Fix:** Add `RUN chown strapi:nodejs /app` in the runner stage, between `corepack enable` and `USER strapi`. This is the load-bearing change.
- **Belt-and-braces:** Set `HOME=/app` in the build stage and `corepack prepare yarn@3.6.4 --activate`, so the corepack cache is baked into `/app/.cache` during build and rides along in the existing `COPY --from=build --chown`. In practice yarn currently self-dispatches via `yarnPath:` in `.yarnrc.yml`, so the corepack download path is bypassed at runtime — but if anyone ever changes `packageManager` via `corepack use`, the cache is already there.
- **Housekeeping:** Bump `engines.node` upper bound to `<=22.x.x` to match the `node:22.20.0-bookworm-slim` base image.

The previous three "Fixes a corepack dependency on the Dockerfiles" commits (`a344fec`, `19bc155`, `bfdd044`) each treated a symptom (enable corepack, set `HOME`, disable download prompt) without addressing the underlying filesystem permission — classic 3-failed-fixes-means-wrong-architecture pattern.

## Test plan

- [x] **Local image build succeeds:** `docker build -f cms/Dockerfile.prod -t ccsa-cms:fix cms` exits 0.
- [x] **Container runs as `strapi`:** `id` inside container returns `uid=1001(strapi)`.
- [x] **`/app` is owned by `strapi:nodejs`** (the previously root-owned dir): `ls -ld /app` shows `strapi nodejs`.
- [x] **The exact failing operation now succeeds:** `mkdir -p /app/.cache/...` as `strapi` returns success rather than EACCES.
- [x] **`yarn --version` runs cleanly** as `strapi` and prints `3.6.4` (no EACCES, no download prompt block).
- [ ] **Post-merge CI/CD redeploys to staging ELB** and the EB tail log no longer shows the `EACCES`, `connect() failed (113: No route to host)` cascade, or container restart loop.
- [ ] **Staging health checks return to green** and `/cms/api/*` stops 502ing.

## Notes for reviewers / follow-ups not in this PR

- `adduser --system` (no `--ingroup nodejs`) places `strapi` in `nogroup`. The `nodejs` group is created but unused. Not blocking — owner permissions are what save us — but worth a one-word follow-up.
- Two pre-existing BuildKit lint warnings about legacy `ENV key value` format (lines 15 and 54) remain.
- The local `client/.husky/pre-commit` hook calls `yarn lint --fix`, which errors with `unknown option '--fix'` under Yarn 3 (and `cms/` config-sync requires DB env). This commit was made with `--no-verify` (authorized) because neither hook step applies to Dockerfile/package.json changes; the hook itself is broken in non-client commits and deserves its own fix.